### PR TITLE
Tyler/63 replace active toggle

### DIFF
--- a/common_utils/types.ts
+++ b/common_utils/types.ts
@@ -180,7 +180,7 @@ export interface SearchParams {
     secondaryNames?: string[];
     secondaryPhones?: string[];
     beiChapters?: string[];
-    actives?: boolean;
+    active?: boolean;
     countries?: string[];
     states?: string[];
     cities?: string[];

--- a/common_utils/types.ts
+++ b/common_utils/types.ts
@@ -180,7 +180,7 @@ export interface SearchParams {
     secondaryNames?: string[];
     secondaryPhones?: string[];
     beiChapters?: string[];
-    actives?: boolean[];
+    actives?: boolean;
     countries?: string[];
     states?: string[];
     cities?: string[];

--- a/server/mongodb/actions/User.ts
+++ b/server/mongodb/actions/User.ts
@@ -101,7 +101,7 @@ type UParam = {
   "location.city"?: object;
   additionalAffiliation?: object;
   beiChapter?: object;
-  "analyticsRecords.active"?: object;
+  "analyticsRecords.active"?: boolean;
 };
 
 export const getUsersFiltered = async ({
@@ -150,8 +150,8 @@ export const getUsersFiltered = async ({
   if (paramsObject.beiChapters) {
     userParamsObject.beiChapter = { $in: paramsObject.beiChapters };
   }
-  if (paramsObject.actives) {
-    userParamsObject["analyticsRecords.active"] = { $in: paramsObject.actives };
+  if (paramsObject.active !== undefined) {
+    userParamsObject["analyticsRecords.active"] = paramsObject.active;
   }
 
   const matchPipeline = {

--- a/src/app/patient/search/page.tsx
+++ b/src/app/patient/search/page.tsx
@@ -25,7 +25,7 @@ export default function Page() {
   const [viewTable, setViewTable] = useState<boolean>(false);
 
   const [fullName, setFullName] = useState("");
-  const [actives, setActives] = useState(new Set<boolean>());
+  const [actives, setActives] = useState<boolean | undefined>(true);
   const [countries, setCountries] = useState(new Set<string>()); // values chosen before the apply button
   const [states, setStates] = useState(new Set<string>());
   const [cities, setCities] = useState(new Set<string>());
@@ -59,7 +59,7 @@ export default function Page() {
               secondaryNames: Array.from(secondaryNames),
               secondaryPhoneNumbers: Array.from(secondaryPhoneNumbers),
               beiChapters: Array.from(beiChapters),
-              actives: Array.from(actives),
+              actives: actives !== undefined ? [actives] : [],
               countries: Array.from(countries),
               states: Array.from(states),
               cities: Array.from(cities),

--- a/src/app/patient/search/page.tsx
+++ b/src/app/patient/search/page.tsx
@@ -25,7 +25,7 @@ export default function Page() {
   const [viewTable, setViewTable] = useState<boolean>(false);
 
   const [fullName, setFullName] = useState("");
-  const [actives, setActives] = useState<boolean | undefined>(undefined);
+  const [active, setActive] = useState<boolean | undefined>(undefined);
   const [countries, setCountries] = useState(new Set<string>()); // values chosen before the apply button
   const [states, setStates] = useState(new Set<string>());
   const [cities, setCities] = useState(new Set<string>());
@@ -59,7 +59,7 @@ export default function Page() {
               secondaryNames: Array.from(secondaryNames),
               secondaryPhoneNumbers: Array.from(secondaryPhoneNumbers),
               beiChapters: Array.from(beiChapters),
-              actives: actives !== undefined ? [actives] : [],
+              active,
               countries: Array.from(countries),
               states: Array.from(states),
               cities: Array.from(cities),
@@ -75,7 +75,7 @@ export default function Page() {
     });
   }, [
     fullName,
-    actives,
+    active,
     countries,
     states,
     cities,
@@ -105,8 +105,8 @@ export default function Page() {
         <div className={styles["search-wrapper"]}>
           <Search
             setFullName={setFullName}
-            actives={actives}
-            setActives={setActives}
+            active={active}
+            setActive={setActive}
             countries={countries}
             setCountries={setCountries}
             states={states}

--- a/src/app/patient/search/page.tsx
+++ b/src/app/patient/search/page.tsx
@@ -25,7 +25,7 @@ export default function Page() {
   const [viewTable, setViewTable] = useState<boolean>(false);
 
   const [fullName, setFullName] = useState("");
-  const [actives, setActives] = useState<boolean | undefined>(true);
+  const [actives, setActives] = useState<boolean | undefined>(undefined);
   const [countries, setCountries] = useState(new Set<string>()); // values chosen before the apply button
   const [states, setStates] = useState(new Set<string>());
   const [cities, setCities] = useState(new Set<string>());

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -67,7 +67,7 @@ interface UpdateParamProp {
   setCountries: Dispatch<SetStateAction<Set<string>>>;
   setStates: Dispatch<SetStateAction<Set<string>>>;
   setCities: Dispatch<SetStateAction<Set<string>>>;
-  setActives: Dispatch<SetStateAction<Set<boolean>>>;
+  setActives: Dispatch<SetStateAction<boolean | undefined>>;
   setDateOfBirths: Dispatch<SetStateAction<Set<string>>>;
   setEmails: Dispatch<SetStateAction<Set<string>>>;
   setDateOfJoins: Dispatch<SetStateAction<Set<string>>>;
@@ -82,7 +82,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
   const [country, setCountry] = useState(""); // values chosen before the aply button
   const [state, setState] = useState("");
   const [city, setCity] = useState("");
-  const [active, setActive] = useState(true);
+  const [active, setActive] = useState<boolean | undefined>(undefined);
   const [dateOfBirth, setDateOfBirth] = useState<string>("");
   const [email, setEmail] = useState("");
   const [additionalAffiliation, setAdditionalAffiliation] = useState("");
@@ -118,11 +118,21 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     [],
   );
 
+  const updateBooleanState = useCallback(
+    (
+      value: boolean | undefined,
+      setBoolean: Dispatch<SetStateAction<boolean | undefined>>,
+    ) => {
+      setBoolean(value);
+    },
+    [],
+  );
+
   const reset = () => {
     setCountry("");
     setState("");
     setCity("");
-    setActive(false);
+    setActive(undefined);
     setDateOfBirth("");
     setEmail("");
     setAdditionalAffiliation("");
@@ -132,7 +142,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
   };
 
   const setFinal = () => {
-    checkAndUpdateList(active, props.setActives);
+    updateBooleanState(active, props.setActives);
     checkAndUpdateList(country, props.setCountries);
     checkAndUpdateList(state, props.setStates);
     checkAndUpdateList(city, props.setCities);
@@ -183,11 +193,22 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
               onChange={handleAlignment}
               aria-label="Platform"
             >
-              <ToggleButton value="allPatients">All Patients</ToggleButton>
-              <ToggleButton value="activePatients">
+              <ToggleButton
+                value="allPatients"
+                onClick={() => setActive(undefined)}
+              >
+                All Patients
+              </ToggleButton>
+              <ToggleButton
+                value="activePatients"
+                onClick={() => setActive(true)}
+              >
                 Active Patients
               </ToggleButton>
-              <ToggleButton value="inactivePatients">
+              <ToggleButton
+                value="inactivePatients"
+                onClick={() => setActive(false)}
+              >
                 Inactive Patients
               </ToggleButton>
             </ToggleButtonGroup>

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -5,11 +5,12 @@ import React, {
   useCallback,
   CSSProperties,
 } from "react";
-import Switch from "react-switch";
 import { SelectChangeEvent } from "@mui/material";
 import { Country, State, City } from "country-state-city";
 import InputField from "@src/components/InputField/InputField";
 import CHAPTERS from "@src/utils/chapters";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import ToggleButton from "@mui/material/ToggleButton";
 import Dropdown, { DropdownProps } from "../../Dropdown/Dropdown";
 import styles from "./AdvancedSearch.module.css";
 import "react-calendar/dist/Calendar.css";
@@ -90,6 +91,15 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
   const [secondaryPhoneNumber, setSecondaryPhoneNumber] = useState("");
   const [secondaryName, setSecondaryName] = useState("");
 
+  const [alignment, setAlignment] = React.useState<string | null>("left");
+
+  const handleAlignment = (
+    event: React.MouseEvent<HTMLElement>,
+    newAlignment: string | null,
+  ) => {
+    setAlignment(newAlignment);
+  };
+
   const checkAndUpdateList = useCallback(
     <T,>(element: T | null, setUpdater: Dispatch<SetStateAction<Set<T>>>) => {
       setUpdater((set) => {
@@ -166,15 +176,22 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
       <div className={styles.button_row}>
         <div className={styles.active_patient_box}>
           <span className={styles.active_patient_box_label}>
-            Active Patient
+            <ToggleButtonGroup
+              color="primary"
+              value={alignment}
+              exclusive
+              onChange={handleAlignment}
+              aria-label="Platform"
+            >
+              <ToggleButton value="allPatients">All Patients</ToggleButton>
+              <ToggleButton value="activePatients">
+                Active Patients
+              </ToggleButton>
+              <ToggleButton value="inactivePatients">
+                Inactive Patients
+              </ToggleButton>
+            </ToggleButtonGroup>
           </span>
-          <Switch
-            onChange={() => setActive(!active)}
-            checked={active}
-            onColor="#008AFC"
-            uncheckedIcon={false}
-            checkedIcon={false}
-          />
         </div>
         <div className={styles.button_row_button} onClick={reset}>
           Clear

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -64,10 +64,11 @@ function SelectDropdown<T>({
 
 interface UpdateParamProp {
   style?: CSSProperties;
+  active: boolean | undefined;
   setCountries: Dispatch<SetStateAction<Set<string>>>;
   setStates: Dispatch<SetStateAction<Set<string>>>;
   setCities: Dispatch<SetStateAction<Set<string>>>;
-  setActives: Dispatch<SetStateAction<boolean | undefined>>;
+  setActive: Dispatch<SetStateAction<boolean | undefined>>;
   setDateOfBirths: Dispatch<SetStateAction<Set<string>>>;
   setEmails: Dispatch<SetStateAction<Set<string>>>;
   setDateOfJoins: Dispatch<SetStateAction<Set<string>>>;
@@ -82,7 +83,6 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
   const [country, setCountry] = useState(""); // values chosen before the aply button
   const [state, setState] = useState("");
   const [city, setCity] = useState("");
-  const [active, setActive] = useState<boolean | undefined>(undefined);
   const [dateOfBirth, setDateOfBirth] = useState<string>("");
   const [email, setEmail] = useState("");
   const [additionalAffiliation, setAdditionalAffiliation] = useState("");
@@ -90,15 +90,6 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
   const [beiChapter, setBeiChapter] = useState("");
   const [secondaryPhoneNumber, setSecondaryPhoneNumber] = useState("");
   const [secondaryName, setSecondaryName] = useState("");
-
-  const [alignment, setAlignment] = React.useState<string | null>("left");
-
-  const handleAlignment = (
-    event: React.MouseEvent<HTMLElement>,
-    newAlignment: string | null,
-  ) => {
-    setAlignment(newAlignment);
-  };
 
   const checkAndUpdateList = useCallback(
     <T,>(element: T | null, setUpdater: Dispatch<SetStateAction<Set<T>>>) => {
@@ -118,21 +109,10 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     [],
   );
 
-  const updateBooleanState = useCallback(
-    (
-      value: boolean | undefined,
-      setBoolean: Dispatch<SetStateAction<boolean | undefined>>,
-    ) => {
-      setBoolean(value);
-    },
-    [],
-  );
-
   const reset = () => {
     setCountry("");
     setState("");
     setCity("");
-    setActive(undefined);
     setDateOfBirth("");
     setEmail("");
     setAdditionalAffiliation("");
@@ -142,7 +122,6 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
   };
 
   const setFinal = () => {
-    updateBooleanState(active, props.setActives);
     checkAndUpdateList(country, props.setCountries);
     checkAndUpdateList(state, props.setStates);
     checkAndUpdateList(city, props.setCities);
@@ -188,26 +167,22 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           <span className={styles.active_patient_box_label}>
             <ToggleButtonGroup
               color="primary"
-              value={alignment}
+              value={String(props.active)}
               exclusive
-              onChange={handleAlignment}
               aria-label="Platform"
             >
               <ToggleButton
-                value="allPatients"
-                onClick={() => setActive(undefined)}
+                value="undefined"
+                onClick={() => props.setActive(undefined)}
               >
                 All Patients
               </ToggleButton>
-              <ToggleButton
-                value="activePatients"
-                onClick={() => setActive(true)}
-              >
+              <ToggleButton value="true" onClick={() => props.setActive(true)}>
                 Active Patients
               </ToggleButton>
               <ToggleButton
-                value="inactivePatients"
-                onClick={() => setActive(false)}
+                value="false"
+                onClick={() => props.setActive(false)}
               >
                 Inactive Patients
               </ToggleButton>

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -13,8 +13,8 @@ import InputField from "../InputField/InputField";
 interface SearchProps {
   className?: string;
   setFullName: React.Dispatch<React.SetStateAction<string>>;
-  actives: Set<boolean>;
-  setActives: React.Dispatch<React.SetStateAction<Set<boolean>>>;
+  actives: boolean | undefined;
+  setActives: React.Dispatch<React.SetStateAction<boolean | undefined>>;
   countries: Set<string>;
   setCountries: React.Dispatch<React.SetStateAction<Set<string>>>;
   states: Set<string>;
@@ -70,7 +70,7 @@ export default function Search({
 
   const tagsPresent = useMemo(
     () =>
-      actives.size > 0 ||
+      actives !== undefined ||
       countries.size > 0 ||
       states.size > 0 ||
       cities.size > 0 ||
@@ -160,17 +160,14 @@ export default function Search({
                   setList={setCities}
                 />
               ))}
-            {actives.size > 0 &&
-              Array.from(actives).map((active) => (
-                <Tag
-                  key={`active-${active}`}
-                  title="Status"
-                  value={active}
-                  list={actives}
-                  setList={setActives}
-                  transformData={(val) => (val ? "Active" : "Inactive")}
-                />
-              ))}
+            {actives !== undefined && (
+              <Tag
+                key={`active-${actives}`}
+                title="Status"
+                value={actives}
+                transformData={(val) => (val ? "Active" : "Inactive")}
+              />
+            )}
             {dateOfBirths.size > 0 &&
               Array.from(dateOfBirths).map((dob) => (
                 <Tag

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -13,8 +13,8 @@ import InputField from "../InputField/InputField";
 interface SearchProps {
   className?: string;
   setFullName: React.Dispatch<React.SetStateAction<string>>;
-  actives: boolean | undefined;
-  setActives: React.Dispatch<React.SetStateAction<boolean | undefined>>;
+  active: boolean | undefined;
+  setActive: React.Dispatch<React.SetStateAction<boolean | undefined>>;
   countries: Set<string>;
   setCountries: React.Dispatch<React.SetStateAction<Set<string>>>;
   states: Set<string>;
@@ -41,8 +41,8 @@ interface SearchProps {
 export default function Search({
   className,
   setFullName,
-  actives,
-  setActives,
+  active,
+  setActive,
   countries,
   setCountries,
   states,
@@ -70,7 +70,7 @@ export default function Search({
 
   const tagsPresent = useMemo(
     () =>
-      actives !== undefined ||
+      active !== undefined ||
       countries.size > 0 ||
       states.size > 0 ||
       cities.size > 0 ||
@@ -82,7 +82,7 @@ export default function Search({
       secondaryPhoneNumbers.size > 0 ||
       secondaryNames.size > 0,
     [
-      actives,
+      active,
       countries,
       states,
       cities,
@@ -160,12 +160,13 @@ export default function Search({
                   setList={setCities}
                 />
               ))}
-            {actives !== undefined && (
+            {active !== undefined && (
               <Tag
-                key={`active-${actives}`}
+                key={`active-${active}`}
                 title="Status"
-                value={actives}
+                value={active}
                 transformData={(val) => (val ? "Active" : "Inactive")}
+                onClick={() => setActive(undefined)}
               />
             )}
             {dateOfBirths.size > 0 &&
@@ -252,7 +253,8 @@ export default function Search({
           )}
         >
           <AdvancedSearch
-            setActives={setActives}
+            active={active}
+            setActive={setActive}
             setCountries={setCountries}
             setStates={setStates}
             setCities={setCities}

--- a/src/components/Search/Tag/Tag.tsx
+++ b/src/components/Search/Tag/Tag.tsx
@@ -9,6 +9,7 @@ type TagProps<T> = {
   list?: Set<T>;
   setList?: Dispatch<SetStateAction<Set<T>>>;
   transformData?: (value: T) => string;
+  onClick?: () => void;
 };
 
 export default function Tag<T>({
@@ -17,6 +18,7 @@ export default function Tag<T>({
   list,
   setList,
   transformData,
+  onClick,
 }: TagProps<T>) {
   const [closeTag, setCloseTag] = useState(false);
 
@@ -26,6 +28,9 @@ export default function Tag<T>({
       const newList = new Set<T>(list);
       newList.delete(value);
       setList(newList);
+    }
+    if (onClick) {
+      onClick();
     }
   };
 


### PR DESCRIPTION
## Replace Active Patient Toggle in Advanced Search

Issue Number(s): #63

What does this PR change and why?
The PR changes the `active` switch to a triple toggle button for a more reasonable and intuitive approach for the advanced search.

### Checklist

- [x] Read and understand the relevant codebase
- [x] Replace the Active toggle switch in the Advanced Filters tab

### Critical Changes

- Replaced the Active toggle switch in the Advanced Filters tab

### Related PRs

- N/A

### Testing

1. Navigate to `/patient/search`
2. Click `Advanced Filter` button
3. Witness the new toggle button (click any of the options, then click apply)
