### PR TITLE
Thanasis/65 increase responsiveness

### DIFF
--- a/src/components/Dashboard/MathScreen/MathScreen.tsx
+++ b/src/components/Dashboard/MathScreen/MathScreen.tsx
@@ -54,6 +54,7 @@ const MathScreen = ({
             gradient={true}
             info="Vidushi"
             data={accuracyData}
+            fullWidth
             // style={{ width: "100%", height: "100%" }}
           />
           <LineChart
@@ -65,6 +66,7 @@ const MathScreen = ({
             gradient={true}
             info="Vidushi"
             data={difficultyData}
+            fullWidth
             // style={{ width: "100%", height: "100%" }}
           />
           <BarChart
@@ -74,6 +76,7 @@ const MathScreen = ({
             data={numQuestionData}
             hoverable
             percentageChange
+            fullWidth
             // style={{ width: "100%", height: "100%" }}
           />
           <BarChart
@@ -83,6 +86,7 @@ const MathScreen = ({
             data={timeData}
             hoverable
             percentageChange
+            fullWidth
             // style={{ width: "100%", height: "100%" }}
           />
         </div>

--- a/src/components/Dashboard/OverallDashboard/OverallDashboard.module.scss
+++ b/src/components/Dashboard/OverallDashboard/OverallDashboard.module.scss
@@ -77,7 +77,7 @@
       row-gap: 17px;
 
       .box {
-        width: 250px;
+        width: 100%;
         height: 78px;
       }
     }
@@ -99,15 +99,19 @@
         color: #2b3674;
       }
 
-      .boxes {
+      .verBoxes {
         display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
+        flex-direction: column;
         column-gap: 14px;
         row-gap: 14px;
-
+      }
+      .horBoxes {
+        display: flex;
+        flex-direction: row;
+        column-gap: 14px;
+        row-gap: 14px;
         .box {
-          width: 250px;
+          width: 100%;
           height: 100px;
         }
       }

--- a/src/components/Dashboard/OverallDashboard/OverallDashboard.tsx
+++ b/src/components/Dashboard/OverallDashboard/OverallDashboard.tsx
@@ -165,7 +165,7 @@ export default function OverallDashboard(params: Params) {
                 text={"13"}
                 Icon={QI}
                 Chip={() => <Chip color="#FBBC054D">Trivia</Chip>}
-              />  
+              />
             </div>
           </div>
         </div>

--- a/src/components/Dashboard/OverallDashboard/OverallDashboard.tsx
+++ b/src/components/Dashboard/OverallDashboard/OverallDashboard.tsx
@@ -131,7 +131,7 @@ export default function OverallDashboard(params: Params) {
           data={params.sessionCompletionHistory}
           highlightLargest
           fullWidth
-          style={{width: '30%'}}
+          style={{ width: "30%" }}
         />
 
         <div className={styles.lastSession}>

--- a/src/components/Dashboard/OverallDashboard/OverallDashboard.tsx
+++ b/src/components/Dashboard/OverallDashboard/OverallDashboard.tsx
@@ -134,35 +134,39 @@ export default function OverallDashboard(params: Params) {
 
         <div className={styles.lastSession}>
           <p className={styles.title}>Last Session</p>
-          <div className={styles.boxes}>
-            <SmallDataBox
-              className={styles.box}
-              title="Questions Completed"
-              text={"10"}
-              Icon={SQ}
-              Chip={() => <Chip color="#FF9FB34D">Math</Chip>}
-            />
-            <SmallDataBox
-              className={styles.box}
-              title="Prompts Completed"
-              text={"20"}
-              Icon={DI}
-              Chip={() => <Chip color="#32D29633">Writing</Chip>}
-            />
-            <SmallDataBox
-              className={styles.box}
-              title="Words Read Per Min"
-              text={"24.8"}
-              Icon={BI}
-              Chip={() => <Chip color="#008AFC1A">Reading</Chip>}
-            />
-            <SmallDataBox
-              className={styles.box}
-              title="Questions Completed"
-              text={"13"}
-              Icon={QI}
-              Chip={() => <Chip color="#FBBC054D">Trivia</Chip>}
-            />
+          <div className={styles.verBoxes}>
+            <div className={styles.horBoxes}>
+              <SmallDataBox
+                className={styles.box}
+                title="Questions Completed"
+                text={"10"}
+                Icon={SQ}
+                Chip={() => <Chip color="#FF9FB34D">Math</Chip>}
+              />
+              <SmallDataBox
+                className={styles.box}
+                title="Prompts Completed"
+                text={"20"}
+                Icon={DI}
+                Chip={() => <Chip color="#32D29633">Writing</Chip>}
+              />
+            </div>
+            <div className={styles.horBoxes}>
+              <SmallDataBox
+                className={styles.box}
+                title="Words Read Per Min"
+                text={"24.8"}
+                Icon={BI}
+                Chip={() => <Chip color="#008AFC1A">Reading</Chip>}
+              />
+              <SmallDataBox
+                className={styles.box}
+                title="Questions Completed"
+                text={"13"}
+                Icon={QI}
+                Chip={() => <Chip color="#FBBC054D">Trivia</Chip>}
+              />  
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/Dashboard/OverallDashboard/OverallDashboard.tsx
+++ b/src/components/Dashboard/OverallDashboard/OverallDashboard.tsx
@@ -130,6 +130,8 @@ export default function OverallDashboard(params: Params) {
           title="Session Completion History"
           data={params.sessionCompletionHistory}
           highlightLargest
+          fullWidth
+          style={{width: '30%'}}
         />
 
         <div className={styles.lastSession}>

--- a/src/components/Dashboard/ReadingScreen/ReadingScreen.tsx
+++ b/src/components/Dashboard/ReadingScreen/ReadingScreen.tsx
@@ -76,6 +76,7 @@ export default function ReadingScreen({
             ]}
             hoverable
             percentageChange
+            fullWidth
           />
           <BarChart
             width={325}
@@ -84,6 +85,7 @@ export default function ReadingScreen({
             data={avgPassage}
             hoverable
             percentageChange
+            fullWidth
             // style={{ width: "100%", height: "100%" }}
           />
           <LineChart
@@ -95,6 +97,7 @@ export default function ReadingScreen({
             gradient={true}
             info="Vidushi"
             data={readingRate}
+            fullWidth
             // style={{ width: "100%", height: "100%" }}
           />
           <BarChart
@@ -104,6 +107,7 @@ export default function ReadingScreen({
             data={timeData}
             hoverable
             percentageChange
+            fullWidth
             // style={{ width: "100%", height: "100%" }}
             info="Hey this is just some info I thought you will find interesting."
           />

--- a/src/components/Dashboard/TriviaScreen/TriviaScreen.tsx
+++ b/src/components/Dashboard/TriviaScreen/TriviaScreen.tsx
@@ -62,6 +62,7 @@ export default function TriviaScreen({
             gradient={true}
             info="Vidushi"
             data={accuracyData}
+            fullWidth
             // style={{ width: "100%", height: "100%" }}
           />
           <BarChart
@@ -71,6 +72,7 @@ export default function TriviaScreen({
             data={timeData}
             hoverable
             percentageChange
+            fullWidth
             // style={{ width: "100%", height: "100%" }}
           />
           <BarChart
@@ -80,6 +82,7 @@ export default function TriviaScreen({
             data={numQuestionData}
             hoverable
             percentageChange
+            fullWidth
             // style={{ width: "100%", height: "100%" }}
           />
         </div>

--- a/src/components/Dashboard/WritingScreen/WritingScreen.tsx
+++ b/src/components/Dashboard/WritingScreen/WritingScreen.tsx
@@ -60,6 +60,7 @@ export default function WritingScreen({
             info="Some really extremely interesting information about stacked bar chart."
             hoverable
             percentageChange
+            fullWidth
           />
           <BarChart
             width={325}
@@ -68,6 +69,7 @@ export default function WritingScreen({
             data={numCompleted}
             hoverable
             percentageChange
+            fullWidth
             // style={{ width: "100%", height: "100%" }}
             info="Some info for testing purposes in bar chart"
           />
@@ -79,6 +81,7 @@ export default function WritingScreen({
             info="Some info for testing purposes in bar chart"
             hoverable
             percentageChange
+            fullWidth
             // style={{ width: "100%", height: "100%" }}
           />
         </div>

--- a/src/components/Graphs/BarChart/BarChart.tsx
+++ b/src/components/Graphs/BarChart/BarChart.tsx
@@ -49,17 +49,17 @@ export default function BarChart({
   const barWidth = 20;
   const minWidth = (barWidth + 5) * data.length + 60;
   const [width, setWidth] = useState(Math.max(providedWidth, minWidth));
-  const windowSizeRef = useRef(null);
+  const windowSizeRef = useRef<null | HTMLDivElement>(null);
   const updateSize = () => {
-    if (!fullWidth) return;
+    if (!fullWidth || !windowSizeRef.current) return;
     setWidth(Math.max(windowSizeRef.current.offsetWidth - 44, minWidth));
-  }
-  const resizeRef = useRef<any>(undefined);
+  };
+  const resizeRef = useRef<undefined | NodeJS.Timeout>(undefined);
   const resizeOptimised = () => {
     clearTimeout(resizeRef.current);
     resizeRef.current = setTimeout(updateSize, 500);
   };
-  window.addEventListener('resize', resizeOptimised);
+  window.addEventListener("resize", resizeOptimised);
   const height = Math.max(providedHeight, 80);
   const infoButtonRef = useRef(null);
   const marginTop = 20;
@@ -182,7 +182,7 @@ export default function BarChart({
       .style("color", "#A5A5A5")
       .call(yAxisLabel)
       .call((g) => g.select(".domain").remove());
-    
+
     return () => window.removeEventListener("scroll", onScroll);
   }, [
     data,
@@ -195,10 +195,10 @@ export default function BarChart({
     yAxis.min,
     yAxis.numDivisions,
   ]);
-  
+
   useEffect(() => {
     resizeOptimised();
-  }, [])
+  }, []);
 
   const HoverableNode = ({ i, d }: { i: number; d: D3Data["data"][0] }) =>
     activeIndex === i && (
@@ -225,12 +225,12 @@ export default function BarChart({
     <div
       className={styles.BarChart}
       style={{
-        width: fullWidth ? '100%' : width + 44,
+        width: fullWidth ? "100%" : width + 44,
         minWidth: fullWidth ? minWidth + 44 : undefined,
         height: height + 70,
         ...style,
       }}
-      ref = {windowSizeRef}
+      ref={windowSizeRef}
       onClick={() => {
         if (infoPopup) {
           setInfoPopup(false);

--- a/src/components/Graphs/BarChart/BarChart.tsx
+++ b/src/components/Graphs/BarChart/BarChart.tsx
@@ -42,11 +42,24 @@ export default function BarChart({
   hoverable = false,
   percentageChange = false,
   highlightLargest = true,
+  fullWidth = false,
   children,
   info = "",
 }: DataParams) {
   const barWidth = 20;
-  const width = Math.max(providedWidth, (barWidth + 5) * data.length + 60);
+  const minWidth = (barWidth + 5) * data.length + 60;
+  const [width, setWidth] = useState(Math.max(providedWidth, minWidth));
+  const windowSizeRef = useRef(null);
+  const updateSize = () => {
+    if (!fullWidth) return;
+    setWidth(Math.max(windowSizeRef.current.offsetWidth - 44, minWidth));
+  }
+  const resizeRef = useRef<any>(undefined);
+  const resizeOptimised = () => {
+    clearTimeout(resizeRef.current);
+    resizeRef.current = setTimeout(updateSize, 500);
+  };
+  window.addEventListener('resize', resizeOptimised);
   const height = Math.max(providedHeight, 80);
   const infoButtonRef = useRef(null);
   const marginTop = 20;
@@ -169,6 +182,7 @@ export default function BarChart({
       .style("color", "#A5A5A5")
       .call(yAxisLabel)
       .call((g) => g.select(".domain").remove());
+    
     return () => window.removeEventListener("scroll", onScroll);
   }, [
     data,
@@ -181,6 +195,10 @@ export default function BarChart({
     yAxis.min,
     yAxis.numDivisions,
   ]);
+  
+  useEffect(() => {
+    resizeOptimised();
+  }, [])
 
   const HoverableNode = ({ i, d }: { i: number; d: D3Data["data"][0] }) =>
     activeIndex === i && (
@@ -207,10 +225,12 @@ export default function BarChart({
     <div
       className={styles.BarChart}
       style={{
-        width: width + 44,
+        width: fullWidth ? '100%' : width + 44,
+        minWidth: fullWidth ? minWidth + 44 : undefined,
         height: height + 70,
         ...style,
       }}
+      ref = {windowSizeRef}
       onClick={() => {
         if (infoPopup) {
           setInfoPopup(false);

--- a/src/components/Graphs/LineChart/LineChart.module.scss
+++ b/src/components/Graphs/LineChart/LineChart.module.scss
@@ -10,11 +10,22 @@
 
 .titleBox {
   display: inline-flex;
+  width: 100%;
+  height: 1.25em;
   p {
     font-family: var(--font-poppins);
     font-weight: 500;
     color: #a3aed0;
     font-size: 12px;
+  }
+  .titleText {
+    white-space: nowrap;
+    overflow: scroll;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .titleText::-webkit-scrollbar {
+    display: none;
   }
   .percentageChangeIcon {
     font-family: var(--font-inter);
@@ -23,6 +34,7 @@
     margin-top: auto;
     margin-bottom: auto;
     margin-left: 12px;
+    white-space: nowrap;
   }
   .percentageChange {
     font-family: var(--font-poppins);

--- a/src/components/Graphs/LineChart/LineChart.tsx
+++ b/src/components/Graphs/LineChart/LineChart.tsx
@@ -41,17 +41,17 @@ export default function LineChart({
 }: DataParams) {
   const minWidth = 210;
   const [width, setWidth] = useState(Math.max(providedWidth, minWidth));
-  const windowSizeRef = useRef(null);
-  const updateSize = ()=>{
-    if(!fullWidth) return;
+  const windowSizeRef = useRef<null | HTMLDivElement>(null);
+  const updateSize = () => {
+    if (!fullWidth || !windowSizeRef.current) return;
     setWidth(Math.max(windowSizeRef.current.offsetWidth - 45, minWidth));
-  }
-  const resizeRef = useRef<any>(undefined);
-  const resizeOptimised =  () => {
+  };
+  const resizeRef = useRef<undefined | NodeJS.Timeout>(undefined);
+  const resizeOptimised = () => {
     clearTimeout(resizeRef.current);
     resizeRef.current = setTimeout(updateSize, 500);
   };
-  window.addEventListener('resize', resizeOptimised);
+  window.addEventListener("resize", resizeOptimised);
   const height = Math.max(providedHeight, 100);
   const infoButtonRef = useRef(null);
   const marginTop = 20;
@@ -168,16 +168,16 @@ export default function LineChart({
     yAxis.min,
     yAxis.numDivisions,
   ]);
-  
+
   useEffect(() => {
     resizeOptimised();
-  }, [])
+  }, []);
 
   return (
     <div
       className={`${className} ${styles.LineChart}`}
       style={{
-        width: fullWidth? '100%': width + 45,
+        width: fullWidth ? "100%" : width + 45,
         minWidth: fullWidth ? minWidth + 45 : undefined,
         height: height + 60,
         ...style,

--- a/src/components/Graphs/LineChart/LineChart.tsx
+++ b/src/components/Graphs/LineChart/LineChart.tsx
@@ -190,7 +190,7 @@ export default function LineChart({
       }}
     >
       <div className={styles.titleBox}>
-        <p>{title}</p>
+        <p className={styles.titleText}>{title}</p>
         {info !== "" && (
           <div
             className={styles.info}

--- a/src/components/Graphs/LineChart/LineChart.tsx
+++ b/src/components/Graphs/LineChart/LineChart.tsx
@@ -36,9 +36,22 @@ export default function LineChart({
   hoverable = false,
   percentageChange = false,
   gradient = false,
+  fullWidth,
   info = "",
 }: DataParams) {
-  const width = Math.max(providedWidth, 210);
+  const minWidth = 210;
+  const [width, setWidth] = useState(Math.max(providedWidth, minWidth));
+  const windowSizeRef = useRef(null);
+  const updateSize = ()=>{
+    if(!fullWidth) return;
+    setWidth(Math.max(windowSizeRef.current.offsetWidth - 45, minWidth));
+  }
+  const resizeRef = useRef<any>(undefined);
+  const resizeOptimised =  () => {
+    clearTimeout(resizeRef.current);
+    resizeRef.current = setTimeout(updateSize, 500);
+  };
+  window.addEventListener('resize', resizeOptimised);
   const height = Math.max(providedHeight, 100);
   const infoButtonRef = useRef(null);
   const marginTop = 20;
@@ -155,15 +168,21 @@ export default function LineChart({
     yAxis.min,
     yAxis.numDivisions,
   ]);
+  
+  useEffect(() => {
+    resizeOptimised();
+  }, [])
 
   return (
     <div
       className={`${className} ${styles.LineChart}`}
       style={{
-        width: width + 45,
+        width: fullWidth? '100%': width + 45,
+        minWidth: fullWidth ? minWidth + 45 : undefined,
         height: height + 60,
         ...style,
       }}
+      ref={windowSizeRef}
       onClick={() => {
         if (infoPopup) {
           setInfoPopup(false);

--- a/src/components/Graphs/StackedBarChart/StackedBarChart.module.scss
+++ b/src/components/Graphs/StackedBarChart/StackedBarChart.module.scss
@@ -1,7 +1,7 @@
 .StackedBarChart {
   background-color: white;
   border-radius: 10px;
-  width: fit-content;
+  overflow: hidden;
   height: fit-content;
 }
 

--- a/src/components/Graphs/StackedBarChart/StackedBarChart.tsx
+++ b/src/components/Graphs/StackedBarChart/StackedBarChart.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as d3 from "d3";
 import { Fragment, useEffect, useRef, useState } from "react";
 import { D3Data } from "@src/utils/types";

--- a/src/components/Graphs/StackedBarChart/StackedBarChart.tsx
+++ b/src/components/Graphs/StackedBarChart/StackedBarChart.tsx
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import { Fragment } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import { D3Data } from "@src/utils/types";
 import { StackedDataRecord } from "@/common_utils/types";
 import BarChart from "../BarChart/BarChart";
@@ -29,11 +29,24 @@ export default function StackedBarChart({
   hoverable = false,
   percentageChange = false,
   legend,
+  fullWidth = false,
   info = "",
 }: DataParams) {
   const barWidth = 20;
   // Same rules as BarChart
-  const width = Math.max(providedWidth, (barWidth + 5) * data.length + 60);
+  const [width, setWidth] = useState(Math.max(providedWidth, (barWidth + 5) * data.length + 60));
+  const windowSizeRef = useRef(null);
+  const updateSize = () => {
+    if(!fullWidth) return;
+    setWidth(windowSizeRef.current.offsetWidth - 44);
+    console.log("Barchart ", width);
+  }
+  const resizeRef = useRef<any>(undefined);
+  const resizeOptimised = () => {
+    clearTimeout(resizeRef.current);
+    resizeRef.current = setTimeout(updateSize, 500);
+  };
+  window.addEventListener('resize', resizeOptimised);
   const height = Math.max(providedHeight, 80);
   const marginTop = 20;
   const marginRight = 25;
@@ -47,8 +60,11 @@ export default function StackedBarChart({
     [yAxis.min, yAxis.max],
     [height - marginBottom, marginTop],
   );
+  useEffect(() => {
+    resizeOptimised();
+  }, [])
   return (
-    <div className={styles.StackedBarChart}>
+    <div className={styles.StackedBarChart} style={{width: fullWidth ? '100%' : 'fit-content'}} ref={windowSizeRef}>
       <BarChart
         title={title}
         data={data}
@@ -59,6 +75,7 @@ export default function StackedBarChart({
         hoverable={hoverable}
         percentageChange={percentageChange}
         info={info}
+        fullWidth
       >
         {data.map((d, i) => (
           <Fragment key={i}>

--- a/src/components/Graphs/StackedBarChart/StackedBarChart.tsx
+++ b/src/components/Graphs/StackedBarChart/StackedBarChart.tsx
@@ -34,19 +34,20 @@ export default function StackedBarChart({
 }: DataParams) {
   const barWidth = 20;
   // Same rules as BarChart
-  const [width, setWidth] = useState(Math.max(providedWidth, (barWidth + 5) * data.length + 60));
-  const windowSizeRef = useRef(null);
+  const [width, setWidth] = useState(
+    Math.max(providedWidth, (barWidth + 5) * data.length + 60),
+  );
+  const windowSizeRef = useRef<null | HTMLDivElement>(null);
   const updateSize = () => {
-    if(!fullWidth) return;
+    if (!fullWidth || !windowSizeRef.current) return;
     setWidth(windowSizeRef.current.offsetWidth - 44);
-    console.log("Barchart ", width);
-  }
-  const resizeRef = useRef<any>(undefined);
+  };
+  const resizeRef = useRef<undefined | NodeJS.Timeout>(undefined);
   const resizeOptimised = () => {
     clearTimeout(resizeRef.current);
     resizeRef.current = setTimeout(updateSize, 500);
   };
-  window.addEventListener('resize', resizeOptimised);
+  window.addEventListener("resize", resizeOptimised);
   const height = Math.max(providedHeight, 80);
   const marginTop = 20;
   const marginRight = 25;
@@ -62,9 +63,13 @@ export default function StackedBarChart({
   );
   useEffect(() => {
     resizeOptimised();
-  }, [])
+  }, []);
   return (
-    <div className={styles.StackedBarChart} style={{width: fullWidth ? '100%' : 'fit-content'}} ref={windowSizeRef}>
+    <div
+      className={styles.StackedBarChart}
+      style={{ width: fullWidth ? "100%" : "fit-content" }}
+      ref={windowSizeRef}
+    >
       <BarChart
         title={title}
         data={data}

--- a/src/components/Graphs/WeeklyProgress/WeeklyProgress.module.scss
+++ b/src/components/Graphs/WeeklyProgress/WeeklyProgress.module.scss
@@ -1,5 +1,6 @@
 .container {
   width: 100%;
+  min-width: 340px;
   height: 175px;
   background-color: white;
   border-radius: 15px;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -12,6 +12,7 @@ export interface D3Data {
   };
   width?: number;
   height?: number;
+  fullWidth?: boolean;
   style?: CSSProperties;
 }
 


### PR DESCRIPTION
## PR Title

Issue Number(s): #65 

What does this PR change and why?

Minor changes to components and major changes to the svg graphs, making them more responsive to window resizing.

### Checklist

- [x] Requirements have been implemented
- [x] Acceptance criteria are met
- [x] Database schema docs have been updated or are not necessary
- [x] Code follows design and style guidelines
- [x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes
- None

### Testing
Try resizing the window as much as possible and observe the changes on the components.

### Notes
The line, bar, and stack charts are not resizable currently. After spending a few hours trying to figure out how to make svgs resizable, I figured it will make the code much less maintainable and more difficult to comprehend. I will continue looking for a solution that works without any issues. As of now, the graphs are fixed sized.

Update: The graphs are now resizable. They can be configured to take up 100% of the width available to them by providing the argument `fullWidth`.

Also, resizing forces a re-render on the svg graphs. This makes the whole app incredibly sluggish when resizing as we could be triggering an update of many components maybe thirty times per second.
Instead, I have implemented some simple logic that makes the re-render happen only after we have stopped resizing for about half a second. I.e. we give a 0.5s buffer to resize the window without forcing a render.
