### PR TITLE
Continuous Reload Bug on Hosted Sites

### DIFF
--- a/src/components/FirebaseAuthGuard/FirebaseAuthGuard.tsx
+++ b/src/components/FirebaseAuthGuard/FirebaseAuthGuard.tsx
@@ -20,9 +20,8 @@ export default function FirebaseAuthGuard({
   useEffect(() => {
     const unsubscribe = getAuth().onAuthStateChanged((user) => {
       if (!user) {
-        console.log("FirebaseAuthGuard: User is not logged in");
+        // Do not redirect after logging out. The middleware will handle that on page reload.
         dispatch(logout());
-        // router.push("/auth/login");
       }
     });
     return unsubscribe;

--- a/src/components/FirebaseAuthGuard/FirebaseAuthGuard.tsx
+++ b/src/components/FirebaseAuthGuard/FirebaseAuthGuard.tsx
@@ -22,7 +22,7 @@ export default function FirebaseAuthGuard({
       if (!user) {
         console.log("FirebaseAuthGuard: User is not logged in");
         dispatch(logout());
-        router.push("/auth/login");
+        // router.push("/auth/login");
       }
     });
     return unsubscribe;

--- a/src/components/FirebaseAuthGuard/FirebaseAuthGuard.tsx
+++ b/src/components/FirebaseAuthGuard/FirebaseAuthGuard.tsx
@@ -20,11 +20,12 @@ export default function FirebaseAuthGuard({
   useEffect(() => {
     const unsubscribe = getAuth().onAuthStateChanged((user) => {
       if (!user) {
+        console.log("FirebaseAuthGuard: User is not logged in");
         dispatch(logout());
         router.push("/auth/login");
       }
     });
-    return () => unsubscribe();
+    return unsubscribe;
   }, [dispatch, router]);
 
   return <>{children}</>;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,23 +6,29 @@ export async function middleware(request: NextRequest) {
   // Assume a "Cookie:nextjs=fast" header to be present on the incoming request
   // Getting cookies from the request using the `RequestCookies` API
   const path = request.nextUrl.pathname;
+  console.log("here1", path);
   if (path === "/") {
+    console.log("here2");
     return NextResponse.redirect(
       new URL("/auth/login", request.nextUrl.origin),
     );
   }
+  console.log("here3");
 
   const { user = {} as IUser, keepLogged = false } = JSON.parse(
     request.cookies.get("authUser")?.value ?? "{}",
   ) as IAuthUserCookie;
+  console.log("here4", user, keepLogged);
 
   /* Unprotected routes; no need to check for user data */
   if (
     path.match(/\/auth\/password-reset/g) ||
     path.match(/\/auth\/email-verification\/[a-z0-9-]{36}/g)
   ) {
+    console.log("here5");
     return NextResponse.next();
   }
+  console.log("here6");
 
   /*
   1. User does not have a cookie: redirect to /auth/login or /auth/signup if not already there
@@ -35,13 +41,17 @@ export async function middleware(request: NextRequest) {
       iv. SignUp is not true: redirect to /auth/information if not already there
   */
   if (!request.cookies.has("authUser")) {
+    console.log("here7");
     if (path.match(/\/auth\/(login|signup)/g)) {
+      console.log("here8");
       return NextResponse.next();
     }
+    console.log("here9");
     return NextResponse.redirect(
       new URL("/auth/login", request.nextUrl.origin),
     );
   }
+  console.log("here10");
 
   /*
     If the user is already verified and signed up:
@@ -50,11 +60,14 @@ export async function middleware(request: NextRequest) {
         redirecting to `/patient/search`.
   */
   if (user.verified && user.signedUp) {
+    console.log("here11");
     if (path.match(/\/auth\/(login|signup|email-verification|information)/g)) {
+      console.log("here12");
       return NextResponse.redirect(
         new URL("/patient/search", request.nextUrl.origin),
       );
     }
+    console.log("here13");
     return NextResponse.next();
   }
 
@@ -71,22 +84,28 @@ export async function middleware(request: NextRequest) {
       },
     )
   ).json()) as { success: boolean; message: string; payload: object };
+  console.log("here14", response);
 
   /* If the response is not successful, redirect to /auth/login */
   if (!response || response.success === false || !response.payload) {
+    console.log("here15");
     request.cookies.delete("authUser");
     if (path.match(/\/auth\/(login|signup)/g)) {
+      console.log("here16");
       return NextResponse.next();
     }
+    console.log("here17");
     return NextResponse.redirect(
       new URL("/auth/login", request.nextUrl.origin),
     );
   }
+  console.log("here18");
 
   /* Update the cookie with the new user data */
   const fetchedUser = response.payload as IUser;
 
   let Response: NextResponse;
+  console.log("here19", fetchedUser);
 
   /*
     Now, with the refreshed user data, if the user is already verified and signed up:
@@ -95,27 +114,34 @@ export async function middleware(request: NextRequest) {
         redirecting to `/patient/search`.
   */
   if (fetchedUser.verified && fetchedUser.signedUp) {
+    console.log("here20");
     if (path.match(/\/auth\/(login|signup|email-verification|information)/g)) {
+      console.log("here21");
       Response = NextResponse.redirect(
         new URL("/patient/search", request.nextUrl.origin),
       );
     } else {
+      console.log("here22");
       Response = NextResponse.next();
     }
   } else if (!fetchedUser.verified) {
+    console.log("here23");
     /* 
     If the user has not verified their email:
       a. redirect to /auth/email-verification if not already on it
       b. if already on /auth/email-verification, continue to the page
   */
     if (path.match(/auth\/email-verification/g)) {
+      console.log("here24");
       Response = NextResponse.next();
     } else {
+      console.log("here25");
       Response = NextResponse.redirect(
         new URL("/auth/email-verification", request.nextUrl.origin),
       );
     }
   } else {
+    console.log("here26");
     /* 
     The user will only reach here if their email is verified but they have not filled
     out their signup information yet:
@@ -124,19 +150,23 @@ export async function middleware(request: NextRequest) {
   */
     // eslint-disable-next-line no-lonely-if
     if (path.match(/auth\/information/g)) {
+      console.log("here27");
       Response = NextResponse.next();
     } else {
+      console.log("here28");
       Response = NextResponse.redirect(
         new URL("/auth/information", request.nextUrl.origin),
       );
     }
   }
 
+  console.log("here29");
   Response.cookies.set(
     "authUser",
     JSON.stringify({ user: fetchedUser, keepLogged }),
     keepLogged ? { maxAge: 7 * 24 * 60 * 60 } : undefined,
   );
+  console.log("here30");
   return Response;
 }
 


### PR DESCRIPTION
When logged out on the deployed sites, the `FirebaseAuthGuard` component would continuously redirect the user to the `/auth/login` page. This caused an infinite page reload when logged out. This PR fixes that bug by removing the auto-redirect on logout.