### PR TITLE
Store Patient Filters in Redux Reducer

### DIFF
--- a/common_utils/types.ts
+++ b/common_utils/types.ts
@@ -10,11 +10,11 @@ export type RecursivePartial<T> = T extends Date
 /* Internal Request & API Wrapper Types */
 
 export enum HttpMethod {
-  GET = "GET",
-  POST = "POST",
-  PATCH = "PATCH",
-  PUT = "PUT",
-  DELETE = "DELETE",
+  GET = 'GET',
+  POST = 'POST',
+  PATCH = 'PATCH',
+  PUT = 'PUT',
+  DELETE = 'DELETE',
 }
 
 export interface InternalRequestData {
@@ -34,9 +34,9 @@ export interface InternalResponseData<T> {
 export class InternalResponseError extends Error {}
 
 export enum Role {
-  NONPROFIT_PATIENT = "Nonprofit Patient",
-  NONPROFIT_VOLUNTEER = "Nonprofit Volunteer",
-  NONPROFIT_ADMIN = "Nonprofit Admin",
+  NONPROFIT_PATIENT = 'Nonprofit Patient',
+  NONPROFIT_VOLUNTEER = 'Nonprofit Volunteer',
+  NONPROFIT_ADMIN = 'Nonprofit Admin',
 }
 
 export enum Days {
@@ -50,25 +50,25 @@ export enum Days {
 }
 
 export enum AdminApprovalStatus {
-  PENDING = "Pending",
-  APPROVED = "Approved",
-  REJECTED = "Rejected",
+  PENDING = 'Pending',
+  APPROVED = 'Approved',
+  REJECTED = 'Rejected',
 }
 
 export enum DateRangeEnum {
-  RECENT = "Most Recent",
-  QUARTER = "3 Months",
-  HALF = "6 Months",
-  YEAR = "1 Year",
-  MAX = "Max",
+  RECENT = 'Most Recent',
+  QUARTER = '3 Months',
+  HALF = '6 Months',
+  YEAR = '1 Year',
+  MAX = 'Max',
 }
 
 export enum AnalyticsSectionEnum {
-  OVERALL = "overall",
-  MATH = "math",
-  TRIVIA = "trivia",
-  READING = "reading",
-  WRITING = "writing",
+  OVERALL = 'overall',
+  MATH = 'math',
+  TRIVIA = 'trivia',
+  READING = 'reading',
+  WRITING = 'writing',
 }
 
 export interface IUser {
@@ -187,8 +187,8 @@ export interface IOverallAnalytics {
 /* VerificationLog MongoDB Schema Types */
 
 export enum VerificationLogType {
-  PASSWORD_RESET = "PASSWORD_RESET",
-  EMAIL_VERIFICATION = "EMAIL_VERIFICATION",
+  PASSWORD_RESET = 'PASSWORD_RESET',
+  EMAIL_VERIFICATION = 'EMAIL_VERIFICATION',
 }
 
 /* authUser Cookie Type */
@@ -246,6 +246,21 @@ export type PatientSearchParams = {
   dateOfJoins?: string[];
 };
 
+export type IPatientSearchReducer = {
+  fullName: string;
+  active: boolean | undefined;
+  countries: Set<string>;
+  states: Set<string>;
+  cities: Set<string>;
+  dateOfBirths: Set<string>;
+  emails: Set<string>;
+  additionalAffiliations: Set<string>;
+  dateOfJoins: Set<string>;
+  beiChapters: Set<string>;
+  secondaryPhoneNumbers: Set<string>;
+  secondaryNames: Set<string>;
+};
+
 export type VolunteerSearchParams = {
   name?: string;
   approved?: AdminApprovalStatus;
@@ -254,12 +269,12 @@ export type VolunteerSearchParams = {
 export interface IPatientTableEntry
   extends Omit<
     IUser,
-    | "phoneNumber"
-    | "role"
-    | "signedUp"
-    | "verified"
-    | "approved"
-    | "adminDetails"
+    | 'phoneNumber'
+    | 'role'
+    | 'signedUp'
+    | 'verified'
+    | 'approved'
+    | 'adminDetails'
   > {
   active: boolean;
   startDate: Date;

--- a/common_utils/types.ts
+++ b/common_utils/types.ts
@@ -10,11 +10,11 @@ export type RecursivePartial<T> = T extends Date
 /* Internal Request & API Wrapper Types */
 
 export enum HttpMethod {
-  GET = 'GET',
-  POST = 'POST',
-  PATCH = 'PATCH',
-  PUT = 'PUT',
-  DELETE = 'DELETE',
+  GET = "GET",
+  POST = "POST",
+  PATCH = "PATCH",
+  PUT = "PUT",
+  DELETE = "DELETE",
 }
 
 export interface InternalRequestData {
@@ -34,9 +34,9 @@ export interface InternalResponseData<T> {
 export class InternalResponseError extends Error {}
 
 export enum Role {
-  NONPROFIT_PATIENT = 'Nonprofit Patient',
-  NONPROFIT_VOLUNTEER = 'Nonprofit Volunteer',
-  NONPROFIT_ADMIN = 'Nonprofit Admin',
+  NONPROFIT_PATIENT = "Nonprofit Patient",
+  NONPROFIT_VOLUNTEER = "Nonprofit Volunteer",
+  NONPROFIT_ADMIN = "Nonprofit Admin",
 }
 
 export enum Days {
@@ -50,25 +50,25 @@ export enum Days {
 }
 
 export enum AdminApprovalStatus {
-  PENDING = 'Pending',
-  APPROVED = 'Approved',
-  REJECTED = 'Rejected',
+  PENDING = "Pending",
+  APPROVED = "Approved",
+  REJECTED = "Rejected",
 }
 
 export enum DateRangeEnum {
-  RECENT = 'Most Recent',
-  QUARTER = '3 Months',
-  HALF = '6 Months',
-  YEAR = '1 Year',
-  MAX = 'Max',
+  RECENT = "Most Recent",
+  QUARTER = "3 Months",
+  HALF = "6 Months",
+  YEAR = "1 Year",
+  MAX = "Max",
 }
 
 export enum AnalyticsSectionEnum {
-  OVERALL = 'overall',
-  MATH = 'math',
-  TRIVIA = 'trivia',
-  READING = 'reading',
-  WRITING = 'writing',
+  OVERALL = "overall",
+  MATH = "math",
+  TRIVIA = "trivia",
+  READING = "reading",
+  WRITING = "writing",
 }
 
 export interface IUser {
@@ -187,8 +187,8 @@ export interface IOverallAnalytics {
 /* VerificationLog MongoDB Schema Types */
 
 export enum VerificationLogType {
-  PASSWORD_RESET = 'PASSWORD_RESET',
-  EMAIL_VERIFICATION = 'EMAIL_VERIFICATION',
+  PASSWORD_RESET = "PASSWORD_RESET",
+  EMAIL_VERIFICATION = "EMAIL_VERIFICATION",
 }
 
 /* authUser Cookie Type */
@@ -269,12 +269,12 @@ export type VolunteerSearchParams = {
 export interface IPatientTableEntry
   extends Omit<
     IUser,
-    | 'phoneNumber'
-    | 'role'
-    | 'signedUp'
-    | 'verified'
-    | 'approved'
-    | 'adminDetails'
+    | "phoneNumber"
+    | "role"
+    | "signedUp"
+    | "verified"
+    | "approved"
+    | "adminDetails"
   > {
   active: boolean;
   startDate: Date;

--- a/src/app/(management-portal)/patient/search/page.tsx
+++ b/src/app/(management-portal)/patient/search/page.tsx
@@ -39,6 +39,7 @@ export default function Page() {
     secondaryPhoneNumbers,
     secondaryNames,
   } = useSelector((state: RootState) => state.patientSearch);
+  console.log(fullName);
 
   const [sortField, setSortField] = useState<SortField | undefined>(undefined);
   const [filteredUsers, setFilteredUsers] = useState<IPatientTableEntry[]>([]);
@@ -54,23 +55,24 @@ export default function Page() {
           method: HttpMethod.POST,
           body: {
             params: {
-              fullName,
-              dateOfBirths: dateOfBirths,
-              emails: emails,
-              additionalAffiliations: additionalAffiliations,
-              secondaryNames: secondaryNames,
-              secondaryPhoneNumbers,
-              beiChapters: beiChapters,
+              name: fullName,
+              dateOfBirths: Array.from(dateOfBirths),
+              emails: Array.from(emails),
+              additionalAffiliations: Array.from(additionalAffiliations),
+              secondaryNames: Array.from(secondaryNames),
+              secondaryPhoneNumbers: Array.from(secondaryPhoneNumbers),
+              beiChapters: Array.from(beiChapters),
               active,
-              countries: countries,
-              states: states,
-              cities: cities,
-              dateOfJoins: dateOfJoins,
+              countries: Array.from(countries),
+              states: Array.from(states),
+              cities: Array.from(cities),
+              dateOfJoins: Array.from(dateOfJoins),
             },
             page: currentPage,
             sortParams: sortField,
           },
         }).then((res) => {
+          console.log(res);
           setPageCount(res?.numPages ?? 0);
           setFilteredUsers(res?.data ?? []);
         });

--- a/src/app/(management-portal)/patient/search/page.tsx
+++ b/src/app/(management-portal)/patient/search/page.tsx
@@ -25,9 +25,8 @@ firebaseInit();
 
 export default function Page() {
   const dispatch = useDispatch();
-
   const {
-    name: fullName,
+    fullName,
     active,
     countries,
     states,
@@ -37,7 +36,7 @@ export default function Page() {
     additionalAffiliations,
     dateOfJoins,
     beiChapters,
-    secondaryPhones: secondaryPhoneNumbers,
+    secondaryPhoneNumbers,
     secondaryNames,
   } = useSelector((state: RootState) => state.patientSearch);
 
@@ -55,12 +54,12 @@ export default function Page() {
           method: HttpMethod.POST,
           body: {
             params: {
-              name: fullName,
+              fullName,
               dateOfBirths: dateOfBirths,
               emails: emails,
               additionalAffiliations: additionalAffiliations,
               secondaryNames: secondaryNames,
-              secondaryPhoneNumbers: secondaryPhoneNumbers,
+              secondaryPhoneNumbers,
               beiChapters: beiChapters,
               active,
               countries: countries,
@@ -92,6 +91,7 @@ export default function Page() {
     secondaryNames,
     sortField,
     currentPage,
+    dispatch,
   ]);
 
   useEffect(() => {
@@ -110,6 +110,7 @@ export default function Page() {
     secondaryPhoneNumbers,
     secondaryNames,
     sortField,
+    dispatch,
   ]);
 
   return (
@@ -118,7 +119,9 @@ export default function Page() {
         <p className={styles['intro-text']}>
           To begin viewing analytics, search for a patient here!
         </p>
-        <div className={styles['search-wrapper']}>{/* <Search /> */}</div>
+        <div className={styles['search-wrapper']}>
+          <Search />
+        </div>
       </div>
       <div
         className={classes(

--- a/src/app/(management-portal)/patient/search/page.tsx
+++ b/src/app/(management-portal)/patient/search/page.tsx
@@ -1,25 +1,25 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { Dashboard } from '@mui/icons-material';
-import Search from '@src/components/Search/Search';
+import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Dashboard } from "@mui/icons-material";
+import Search from "@src/components/Search/Search";
 
-import PatientGrid from '@src/components/PatientGrid/PatientGrid';
-import { classes } from '@src/utils/utils';
-import { internalRequest } from '@src/utils/requests';
+import PatientGrid from "@src/components/PatientGrid/PatientGrid";
+import { classes } from "@src/utils/utils";
+import { internalRequest } from "@src/utils/requests";
 import {
   SortField,
   HttpMethod,
   IPatientTableEntry,
   SearchResponseBody,
-} from '@/common_utils/types';
+} from "@/common_utils/types";
 
-import { getAuth } from 'firebase/auth';
-import firebaseInit from '@src/firebase/config';
+import { getAuth } from "firebase/auth";
+import firebaseInit from "@src/firebase/config";
 
-import styles from './page.module.css';
-import { RootState } from '@src/redux/rootReducer';
+import { RootState } from "@src/redux/rootReducer";
+import styles from "./page.module.css";
 
 firebaseInit();
 
@@ -51,7 +51,7 @@ export default function Page() {
     getAuth().onAuthStateChanged((user) => {
       if (user) {
         internalRequest<SearchResponseBody<IPatientTableEntry>>({
-          url: '/api/patient/filter-patient',
+          url: "/api/patient/filter-patient",
           method: HttpMethod.POST,
           body: {
             params: {
@@ -117,23 +117,23 @@ export default function Page() {
 
   return (
     <div className={styles.container}>
-      <div className={classes(styles['search-container'])}>
-        <p className={styles['intro-text']}>
+      <div className={classes(styles["search-container"])}>
+        <p className={styles["intro-text"]}>
           To begin viewing analytics, search for a patient here!
         </p>
-        <div className={styles['search-wrapper']}>
+        <div className={styles["search-wrapper"]}>
           <Search />
         </div>
       </div>
       <div
         className={classes(
-          styles['table-container'],
-          styles['table-container-show']
+          styles["table-container"],
+          styles["table-container-show"],
         )}
       >
-        <div className={styles['table-header']}>
+        <div className={styles["table-header"]}>
           <Dashboard />
-          <p className={styles['table-header-text']}>Patient Table</p>
+          <p className={styles["table-header-text"]}>Patient Table</p>
         </div>
         <PatientGrid
           data={filteredUsers}

--- a/src/app/(management-portal)/patient/search/page.tsx
+++ b/src/app/(management-portal)/patient/search/page.tsx
@@ -39,7 +39,6 @@ export default function Page() {
     secondaryPhoneNumbers,
     secondaryNames,
   } = useSelector((state: RootState) => state.patientSearch);
-  console.log(fullName);
 
   const [sortField, setSortField] = useState<SortField | undefined>(undefined);
   const [filteredUsers, setFilteredUsers] = useState<IPatientTableEntry[]>([]);
@@ -72,7 +71,6 @@ export default function Page() {
             sortParams: sortField,
           },
         }).then((res) => {
-          console.log(res);
           setPageCount(res?.numPages ?? 0);
           setFilteredUsers(res?.data ?? []);
         });

--- a/src/app/(management-portal)/patient/search/page.tsx
+++ b/src/app/(management-portal)/patient/search/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { Dashboard } from "@mui/icons-material";
 import Search from "@src/components/Search/Search";
 
@@ -24,7 +24,6 @@ import styles from "./page.module.css";
 firebaseInit();
 
 export default function Page() {
-  const dispatch = useDispatch();
   const {
     fullName,
     active,

--- a/src/app/(management-portal)/patient/search/page.tsx
+++ b/src/app/(management-portal)/patient/search/page.tsx
@@ -91,7 +91,6 @@ export default function Page() {
     secondaryNames,
     sortField,
     currentPage,
-    dispatch,
   ]);
 
   useEffect(() => {
@@ -110,7 +109,6 @@ export default function Page() {
     secondaryPhoneNumbers,
     secondaryNames,
     sortField,
-    dispatch,
   ]);
 
   return (

--- a/src/app/(management-portal)/patient/search/page.tsx
+++ b/src/app/(management-portal)/patient/search/page.tsx
@@ -1,43 +1,45 @@
-"use client";
+'use client';
 
-import { useEffect, useState } from "react";
-import { Dashboard } from "@mui/icons-material";
-import Search from "@src/components/Search/Search";
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Dashboard } from '@mui/icons-material';
+import Search from '@src/components/Search/Search';
 
-import PatientGrid from "@src/components/PatientGrid/PatientGrid";
-import { classes } from "@src/utils/utils";
-import { internalRequest } from "@src/utils/requests";
+import PatientGrid from '@src/components/PatientGrid/PatientGrid';
+import { classes } from '@src/utils/utils';
+import { internalRequest } from '@src/utils/requests';
 import {
   SortField,
   HttpMethod,
   IPatientTableEntry,
   SearchResponseBody,
-} from "@/common_utils/types";
+} from '@/common_utils/types';
 
-import { getAuth } from "firebase/auth";
-import firebaseInit from "@src/firebase/config";
+import { getAuth } from 'firebase/auth';
+import firebaseInit from '@src/firebase/config';
 
-import styles from "./page.module.css";
+import styles from './page.module.css';
+import { RootState } from '@src/redux/rootReducer';
 
 firebaseInit();
 
 export default function Page() {
-  const [fullName, setFullName] = useState("");
-  const [active, setActive] = useState<boolean | undefined>(undefined);
-  const [countries, setCountries] = useState(new Set<string>()); // values chosen before the apply button
-  const [states, setStates] = useState(new Set<string>());
-  const [cities, setCities] = useState(new Set<string>());
-  const [dateOfBirths, setDateOfBirths] = useState(new Set<string>());
-  const [emails, setEmails] = useState(new Set<string>());
-  const [additionalAffiliations, setAdditionalAffiliations] = useState(
-    new Set<string>(),
-  );
-  const [dateOfJoins, setDateOfJoins] = useState(new Set<string>());
-  const [beiChapters, setBeiChapters] = useState(new Set<string>());
-  const [secondaryPhoneNumbers, setSecondaryPhoneNumbers] = useState(
-    new Set<string>(),
-  );
-  const [secondaryNames, setSecondaryNames] = useState(new Set<string>());
+  const dispatch = useDispatch();
+
+  const {
+    name: fullName,
+    active,
+    countries,
+    states,
+    cities,
+    dateOfBirths,
+    emails,
+    additionalAffiliations,
+    dateOfJoins,
+    beiChapters,
+    secondaryPhones: secondaryPhoneNumbers,
+    secondaryNames,
+  } = useSelector((state: RootState) => state.patientSearch);
 
   const [sortField, setSortField] = useState<SortField | undefined>(undefined);
   const [filteredUsers, setFilteredUsers] = useState<IPatientTableEntry[]>([]);
@@ -49,22 +51,22 @@ export default function Page() {
     getAuth().onAuthStateChanged((user) => {
       if (user) {
         internalRequest<SearchResponseBody<IPatientTableEntry>>({
-          url: "/api/patient/filter-patient",
+          url: '/api/patient/filter-patient',
           method: HttpMethod.POST,
           body: {
             params: {
               name: fullName,
-              dateOfBirths: Array.from(dateOfBirths),
-              emails: Array.from(emails),
-              additionalAffiliations: Array.from(additionalAffiliations),
-              secondaryNames: Array.from(secondaryNames),
-              secondaryPhoneNumbers: Array.from(secondaryPhoneNumbers),
-              beiChapters: Array.from(beiChapters),
+              dateOfBirths: dateOfBirths,
+              emails: emails,
+              additionalAffiliations: additionalAffiliations,
+              secondaryNames: secondaryNames,
+              secondaryPhoneNumbers: secondaryPhoneNumbers,
+              beiChapters: beiChapters,
               active,
-              countries: Array.from(countries),
-              states: Array.from(states),
-              cities: Array.from(cities),
-              dateOfJoins: Array.from(dateOfJoins),
+              countries: countries,
+              states: states,
+              cities: cities,
+              dateOfJoins: dateOfJoins,
             },
             page: currentPage,
             sortParams: sortField,
@@ -112,47 +114,21 @@ export default function Page() {
 
   return (
     <div className={styles.container}>
-      <div className={classes(styles["search-container"])}>
-        <p className={styles["intro-text"]}>
+      <div className={classes(styles['search-container'])}>
+        <p className={styles['intro-text']}>
           To begin viewing analytics, search for a patient here!
         </p>
-        <div className={styles["search-wrapper"]}>
-          <Search
-            setFullName={setFullName}
-            active={active}
-            setActive={setActive}
-            countries={countries}
-            setCountries={setCountries}
-            states={states}
-            setStates={setStates}
-            cities={cities}
-            setCities={setCities}
-            dateOfBirths={dateOfBirths}
-            setDateOfBirths={setDateOfBirths}
-            emails={emails}
-            setEmails={setEmails}
-            additionalAffiliations={additionalAffiliations}
-            setAdditionalAffiliations={setAdditionalAffiliations}
-            dateOfJoins={dateOfJoins}
-            setDateOfJoins={setDateOfJoins}
-            beiChapters={beiChapters}
-            setBeiChapters={setBeiChapters}
-            secondaryPhoneNumbers={secondaryPhoneNumbers}
-            setSecondaryPhoneNumbers={setSecondaryPhoneNumbers}
-            secondaryNames={secondaryNames}
-            setSecondaryNames={setSecondaryNames}
-          />
-        </div>
+        <div className={styles['search-wrapper']}>{/* <Search /> */}</div>
       </div>
       <div
         className={classes(
-          styles["table-container"],
-          styles["table-container-show"],
+          styles['table-container'],
+          styles['table-container-show']
         )}
       >
-        <div className={styles["table-header"]}>
+        <div className={styles['table-header']}>
           <Dashboard />
-          <p className={styles["table-header-text"]}>Patient Table</p>
+          <p className={styles['table-header-text']}>Patient Table</p>
         </div>
         <PatientGrid
           data={filteredUsers}

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -9,7 +9,6 @@ import ToggleButton from '@mui/material/ToggleButton';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@src/redux/rootReducer';
 import {
-  setFullName,
   setActive,
   setCountries,
   setStates,
@@ -92,20 +91,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
   const [secondaryName, setSecondaryName] = useState('');
 
   const dispatch = useDispatch();
-  const {
-    fullName,
-    active,
-    countries,
-    states,
-    cities,
-    dateOfBirths,
-    emails,
-    additionalAffiliations,
-    dateOfJoins,
-    beiChapters,
-    secondaryPhoneNumbers,
-    secondaryNames,
-  } = useSelector((state: RootState) => state.patientSearch);
+  const { active } = useSelector((state: RootState) => state.patientSearch);
 
   const resetForm = () => {
     setCountry('');
@@ -115,6 +101,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     setEmail('');
     setAdditionalAffiliation('');
     setDateOfJoin('');
+    setBeiChapter('')
     setSecondaryName('');
     setSecondaryPhoneNumber('');
   };
@@ -178,14 +165,20 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
             >
               <ToggleButton
                 value='undefined'
-                onClick={() => setActive(undefined)}
+                onClick={() => dispatch(setActive(undefined))}
               >
                 All Patients
               </ToggleButton>
-              <ToggleButton value='true' onClick={() => setActive(true)}>
+              <ToggleButton
+                value='true'
+                onClick={() => dispatch(setActive(true))}
+              >
                 Active Patients
               </ToggleButton>
-              <ToggleButton value='false' onClick={() => setActive(false)}>
+              <ToggleButton
+                value='false'
+                onClick={() => dispatch(setActive(false))}
+              >
                 Inactive Patients
               </ToggleButton>
             </ToggleButtonGroup>

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -83,6 +83,14 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
   const [country, setCountry] = useState(''); // values chosen before the aply button
   const [state, setState] = useState('');
   const [city, setCity] = useState('');
+  const [dateOfBirth, setDateOfBirth] = useState<string>('');
+  const [email, setEmail] = useState('');
+  const [additionalAffiliation, setAdditionalAffiliation] = useState('');
+  const [dateOfJoin, setDateOfJoin] = useState<string>('');
+  const [beiChapter, setBeiChapter] = useState('');
+  const [secondaryPhoneNumber, setSecondaryPhoneNumber] = useState('');
+  const [secondaryName, setSecondaryName] = useState('');
+
   const dispatch = useDispatch();
   const {
     fullName,
@@ -99,23 +107,36 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     secondaryNames,
   } = useSelector((state: RootState) => state.patientSearch);
 
+  const resetForm = () => {
+    setCountry('');
+    setState('');
+    setCity('');
+    setDateOfBirth('');
+    setEmail('');
+    setAdditionalAffiliation('');
+    setDateOfJoin('');
+    setSecondaryName('');
+    setSecondaryPhoneNumber('');
+  };
+
   const reset = () => {
+    resetForm();
     dispatch(resetFields());
   };
 
   const setFinal = () => {
-    if (countries) dispatch(setCountries(countries));
-    if (states) dispatch(setStates(states));
-    if (cities) dispatch(setCities(cities));
-    if (dateOfBirths) dispatch(setDateOfBirths(dateOfBirths));
-    if (emails) dispatch(setEmails(emails));
-    if (additionalAffiliations)
-      dispatch(setAdditionalAffiliations(additionalAffiliations));
-    if (dateOfJoins) dispatch(setDateOfJoins(dateOfJoins));
-    if (beiChapters) dispatch(setBeiChapters(beiChapters));
-    if (secondaryPhoneNumbers)
-      dispatch(setSecondaryPhoneNumbers(secondaryPhoneNumbers));
-    if (secondaryNames) dispatch(setSecondaryNames(secondaryNames));
+    if (country) dispatch(setCountries(new Set([country])));
+    if (state) dispatch(setStates(new Set([state])));
+    if (city) dispatch(setCities(new Set([city])));
+    if (dateOfBirth) dispatch(setDateOfBirths(new Set([dateOfBirth])));
+    if (email) dispatch(setEmails(new Set([email])));
+    if (additionalAffiliation)
+      dispatch(setAdditionalAffiliations(new Set([additionalAffiliation])));
+    if (dateOfJoin) dispatch(setDateOfJoins(new Set([dateOfJoin])));
+    if (beiChapter) dispatch(setBeiChapters(new Set([beiChapter])));
+    if (secondaryPhoneNumber)
+      dispatch(setSecondaryPhoneNumbers(new Set([secondaryPhoneNumber])));
+    if (secondaryName) dispatch(setSecondaryNames(new Set([secondaryName])));
     if (props.onSubmit) {
       props.onSubmit();
     }
@@ -177,7 +198,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           className={[styles.button_row_button, styles.button_blue].join(' ')}
           onClick={() => {
             setFinal();
-            // reset();
+            resetForm();
           }}
         >
           Apply
@@ -190,12 +211,11 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           dropdownProps={{
             placeholder: 'Select Country',
             options: COUNTRIES,
-            value: countries,
+            value: country,
             onChange: (e: SelectChangeEvent<unknown>) => {
               setCountry(e.target.value as string);
               setState('');
               setCity('');
-              dispatch(setCountries(new Set([e.target.value as string])));
             },
             showError: false,
           }}
@@ -207,11 +227,10 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           dropdownProps={{
             placeholder: 'Select State',
             options: STATES,
-            value: states,
+            value: state,
             onChange: (e: SelectChangeEvent<unknown>) => {
               setState(e.target.value as string);
               setCity('');
-              dispatch(setStates(new Set([e.target.value as string])));
             },
             showError: false,
           }}
@@ -223,10 +242,9 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           dropdownProps={{
             placeholder: 'Select City',
             options: CITIES,
-            value: cities,
+            value: city,
             onChange: (e: SelectChangeEvent<unknown>) => {
               setCity(e.target.value as string);
-              dispatch(setCities(new Set([e.target.value as string])));
             },
             showError: false,
           }}
@@ -238,9 +256,9 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           dropdownProps={{
             placeholder: 'Select BEI Chapter',
             options: CHAPTERS,
-            value: beiChapters,
+            value: beiChapter,
             onChange: (e: SelectChangeEvent<unknown>) => {
-              dispatch(setBeiChapters(new Set([e.target.value as string])));
+              setBeiChapter(e.target.value as string);
             },
             showError: false,
           }}
@@ -249,13 +267,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
         />
         <div className={styles.question_box}>
           <div className={styles.label}>Date of Birth</div>
-          <CalendarInput
-            value={Array.from(dateOfBirths)[0]}
-            onChange={(newDate) => {
-              const newDateOfBirths = new Set([newDate]);
-              dispatch(setDateOfBirths(newDateOfBirths));
-            }}
-          />
+          <CalendarInput value={dateOfBirth} onChange={setDateOfBirth} />
         </div>
         <div className={styles.question_box}>
           <div className={[styles.label, styles.email_label].join(' ')}>
@@ -265,9 +277,9 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
             type='email'
             className={[styles.answer, styles.email_answer].join(' ')}
             inputFieldClassName={styles.answerInput}
-            value={Array.from(emails)[0]}
+            value={email}
             placeholder='example@domain.com'
-            onChange={(e) => dispatch(setEmails(new Set([e.target.value])))}
+            onChange={(e) => setEmail(e.target.value)}
           />
         </div>
         <div className={styles.question_box}>
@@ -280,21 +292,13 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
             className={[styles.answer, styles.affiliation_answer].join(' ')}
             inputFieldClassName={styles.answerInput}
             placeholder='Enter Additional Affiliation'
-            value={Array.from(additionalAffiliations)[0]}
-            onChange={(e) =>
-              dispatch(setAdditionalAffiliations(new Set([e.target.value])))
-            }
+            onChange={(e) => setAdditionalAffiliation(e.target.value)}
+            value={additionalAffiliation}
           />
         </div>
         <div className={styles.question_box}>
           <div className={styles.label}>Date of Join</div>
-          <CalendarInput
-            value={Array.from(dateOfJoins)[0]}
-            onChange={(newDate) => {
-              const newDateOfJoins = new Set([newDate]);
-              dispatch(setDateOfJoins(newDateOfJoins));
-            }}
-          />
+          <CalendarInput value={dateOfJoin} onChange={setDateOfJoin} />
         </div>
 
         <div className={styles.secondaryInfo}>
@@ -314,10 +318,8 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
               inputFieldClassName={styles.answerInput}
               required={false}
               placeholder='Enter Name'
-              value={Array.from(secondaryNames)[0]}
-              onChange={(e) =>
-                dispatch(setSecondaryNames(new Set([e.target.value])))
-              }
+              value={secondaryName}
+              onChange={(e) => setSecondaryName(e.target.value)}
             />
           </div>
         </div>
@@ -342,10 +344,8 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
               required={false}
               type='tel'
               placeholder='Enter Phone Number'
-              value={Array.from(secondaryPhoneNumbers)[0]}
-              onChange={(e) =>
-                dispatch(setSecondaryPhoneNumbers(new Set([e.target.value])))
-              }
+              value={secondaryPhoneNumber}
+              onChange={(e) => setSecondaryPhoneNumber(e.target.value)}
             />
           </div>
         </div>

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  Dispatch,
-  SetStateAction,
-  useCallback,
-  CSSProperties,
-} from 'react';
+import React, { CSSProperties, useState } from 'react';
 import { SelectChangeEvent } from '@mui/material';
 import { Country, State, City } from 'country-state-city';
 import InputField from '@src/components/InputField/InputField';
@@ -12,10 +6,6 @@ import InputField from '@src/components/InputField/InputField';
 import CHAPTERS from '@src/utils/chapters';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import ToggleButton from '@mui/material/ToggleButton';
-import Dropdown, { DropdownProps } from '../../Dropdown/Dropdown';
-import styles from './AdvancedSearch.module.css';
-import 'react-calendar/dist/Calendar.css';
-import CalendarInput from './CalendarInput';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@src/redux/rootReducer';
 import {
@@ -33,6 +23,11 @@ import {
   setSecondaryNames,
   resetFields,
 } from '@src/redux/reducers/patientSearchReducer';
+import Dropdown, { DropdownProps } from '../../Dropdown/Dropdown';
+import styles from './AdvancedSearch.module.css';
+import 'react-calendar/dist/Calendar.css';
+import CalendarInput from './CalendarInput';
+
 interface SelectDropdownProps<T> {
   title: string;
   style?: CSSProperties;
@@ -85,6 +80,9 @@ interface UpdateParamProp {
 }
 
 export const AdvancedSearch = (props: UpdateParamProp) => {
+  const [country, setCountry] = useState(''); // values chosen before the aply button
+  const [state, setState] = useState('');
+  const [city, setCity] = useState('');
   const dispatch = useDispatch();
   const {
     fullName,
@@ -128,15 +126,15 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     displayValue: `${locCountry.name}`,
   }));
   const countryCode = Country.getAllCountries().filter(
-    (locCountry) => countries === locCountry.name
+    (locCountry) => country === locCountry.name
   )[0]?.isoCode;
 
   const STATES = State.getStatesOfCountry(countryCode).map((locState) => ({
     value: locState.name,
     displayValue: `${locState.name}`,
   }));
-  const stateCode = State.getStatesOfCountry(countryCode).filter((locState) =>
-    states.has(locState.name)
+  const stateCode = State.getStatesOfCountry(countryCode).filter(
+    (locState) => locState.name === state
   )[0]?.isoCode;
 
   const CITIES = City.getCitiesOfState(countryCode, stateCode).map(

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -127,8 +127,8 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     value: locCountry.name,
     displayValue: `${locCountry.name}`,
   }));
-  const countryCode = Country.getAllCountries().filter((locCountry) =>
-    countries.has(locCountry.name)
+  const countryCode = Country.getAllCountries().filter(
+    (locCountry) => countries === locCountry.name,
   )[0]?.isoCode;
 
   const STATES = State.getStatesOfCountry(countryCode).map((locState) => ({

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -20,7 +20,6 @@ import {
   setBeiChapters,
   setSecondaryPhoneNumbers,
   setSecondaryNames,
-  resetFields,
 } from '@src/redux/reducers/patientSearchReducer';
 import Dropdown, { DropdownProps } from '../../Dropdown/Dropdown';
 import styles from './AdvancedSearch.module.css';
@@ -93,7 +92,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
   const dispatch = useDispatch();
   const { active } = useSelector((state: RootState) => state.patientSearch);
 
-  const resetForm = () => {
+  const reset = () => {
     setCountry('');
     setState('');
     setCity('');
@@ -101,14 +100,9 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     setEmail('');
     setAdditionalAffiliation('');
     setDateOfJoin('');
-    setBeiChapter('')
+    setBeiChapter('');
     setSecondaryName('');
     setSecondaryPhoneNumber('');
-  };
-
-  const reset = () => {
-    resetForm();
-    dispatch(resetFields());
   };
 
   const setFinal = () => {
@@ -191,7 +185,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           className={[styles.button_row_button, styles.button_blue].join(' ')}
           onClick={() => {
             setFinal();
-            resetForm();
+            reset();
           }}
         >
           Apply

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -1,13 +1,13 @@
-import React, { CSSProperties, useCallback, useState } from 'react';
-import { SelectChangeEvent } from '@mui/material';
-import { Country, State, City } from 'country-state-city';
-import InputField from '@src/components/InputField/InputField';
+import React, { CSSProperties, useState } from "react";
+import { SelectChangeEvent } from "@mui/material";
+import { Country, State, City } from "country-state-city";
+import InputField from "@src/components/InputField/InputField";
 
-import CHAPTERS from '@src/utils/chapters';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import ToggleButton from '@mui/material/ToggleButton';
-import { useDispatch, useSelector } from 'react-redux';
-import { RootState } from '@src/redux/rootReducer';
+import CHAPTERS from "@src/utils/chapters";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import ToggleButton from "@mui/material/ToggleButton";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@src/redux/rootReducer";
 import {
   setActive,
   setCountries,
@@ -20,11 +20,11 @@ import {
   setBeiChapters,
   setSecondaryPhoneNumbers,
   setSecondaryNames,
-} from '@src/redux/reducers/patientSearchReducer';
-import Dropdown, { DropdownProps } from '../../Dropdown/Dropdown';
-import styles from './AdvancedSearch.module.css';
-import 'react-calendar/dist/Calendar.css';
-import CalendarInput from './CalendarInput';
+} from "@src/redux/reducers/patientSearchReducer";
+import Dropdown, { DropdownProps } from "../../Dropdown/Dropdown";
+import styles from "./AdvancedSearch.module.css";
+import "react-calendar/dist/Calendar.css";
+import CalendarInput from "./CalendarInput";
 
 interface SelectDropdownProps<T> {
   title: string;
@@ -53,16 +53,16 @@ function SelectDropdown<T>({
         <Dropdown
           {...dropdownProps}
           style={{
-            height: '28px',
-            width: '100%',
-            border: 'none',
+            height: "28px",
+            width: "100%",
+            border: "none",
             borderRadius: 0,
           }}
           sx={{
-            '&.MuiOutlinedInput-root': {
-              height: '30px',
-              '& fieldset': {
-                borderRadius: '0px',
+            "&.MuiOutlinedInput-root": {
+              height: "30px",
+              "& fieldset": {
+                borderRadius: "0px",
               },
             },
           }}
@@ -80,16 +80,16 @@ interface UpdateParamProp {
 export const AdvancedSearch = (props: UpdateParamProp) => {
   const dispatch = useDispatch();
 
-  const [country, setCountry] = useState(''); // values chosen before the aply button
-  const [state, setState] = useState('');
-  const [city, setCity] = useState('');
-  const [dateOfBirth, setDateOfBirth] = useState<string>('');
-  const [email, setEmail] = useState('');
-  const [additionalAffiliation, setAdditionalAffiliation] = useState('');
-  const [dateOfJoin, setDateOfJoin] = useState<string>('');
-  const [beiChapter, setBeiChapter] = useState('');
-  const [secondaryPhoneNumber, setSecondaryPhoneNumber] = useState('');
-  const [secondaryName, setSecondaryName] = useState('');
+  const [country, setCountry] = useState(""); // values chosen before the aply button
+  const [state, setState] = useState("");
+  const [city, setCity] = useState("");
+  const [dateOfBirth, setDateOfBirth] = useState<string>("");
+  const [email, setEmail] = useState("");
+  const [additionalAffiliation, setAdditionalAffiliation] = useState("");
+  const [dateOfJoin, setDateOfJoin] = useState<string>("");
+  const [beiChapter, setBeiChapter] = useState("");
+  const [secondaryPhoneNumber, setSecondaryPhoneNumber] = useState("");
+  const [secondaryName, setSecondaryName] = useState("");
 
   const {
     active,
@@ -104,51 +104,64 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     secondaryPhoneNumbers,
     secondaryNames,
   } = useSelector(
-    (patientSearchState: RootState) => patientSearchState.patientSearch
+    (patientSearchState: RootState) => patientSearchState.patientSearch,
   );
 
+  const checkAndUpdateList = (
+    currentSet: Set<string> | undefined,
+    value: string,
+  ): Set<string> => {
+    const safeCurrentSet =
+      currentSet instanceof Set ? currentSet : new Set<string>();
+    const updatedSet = new Set(safeCurrentSet);
+    if (value) updatedSet.add(value);
+    return updatedSet;
+  };
+
   const reset = () => {
-    setCountry('');
-    setState('');
-    setCity('');
-    setDateOfBirth('');
-    setEmail('');
-    setAdditionalAffiliation('');
-    setDateOfJoin('');
-    setBeiChapter('');
-    setSecondaryName('');
-    setSecondaryPhoneNumber('');
+    setCountry("");
+    setState("");
+    setCity("");
+    setDateOfBirth("");
+    setEmail("");
+    setAdditionalAffiliation("");
+    setDateOfJoin("");
+    setBeiChapter("");
+    setSecondaryName("");
+    setSecondaryPhoneNumber("");
   };
 
   const setFinal = () => {
-    const addToSet = (currentSet: Set<string>, value: string): Set<string> => {
-      const updatedSet = new Set(currentSet);
-      if (value) updatedSet.add(value);
-      return updatedSet;
-    };
+    const dispatchMappings = [
+      { condition: country, action: setCountries, value: countries },
+      { condition: state, action: setStates, value: states },
+      { condition: city, action: setCities, value: cities },
+      { condition: dateOfBirth, action: setDateOfBirths, value: dateOfBirths },
+      { condition: email, action: setEmails, value: emails },
+      {
+        condition: additionalAffiliation,
+        action: setAdditionalAffiliations,
+        value: additionalAffiliations,
+      },
+      { condition: dateOfJoin, action: setDateOfJoins, value: dateOfJoins },
+      { condition: beiChapter, action: setBeiChapters, value: beiChapters },
+      {
+        condition: secondaryPhoneNumber,
+        action: setSecondaryPhoneNumbers,
+        value: secondaryPhoneNumbers,
+      },
+      {
+        condition: secondaryName,
+        action: setSecondaryNames,
+        value: secondaryNames,
+      },
+    ];
 
-    if (country) dispatch(setCountries(addToSet(countries, country)));
-    if (state) dispatch(setStates(addToSet(states, state)));
-    if (city) dispatch(setCities(addToSet(cities, city)));
-    if (dateOfBirth)
-      dispatch(setDateOfBirths(addToSet(dateOfBirths, dateOfBirth)));
-    if (email) dispatch(setEmails(addToSet(emails, email)));
-    if (additionalAffiliation)
-      dispatch(
-        setAdditionalAffiliations(
-          addToSet(additionalAffiliations, additionalAffiliation)
-        )
-      );
-    if (dateOfJoin) dispatch(setDateOfJoins(addToSet(dateOfJoins, dateOfJoin)));
-    if (beiChapter) dispatch(setBeiChapters(addToSet(beiChapters, beiChapter)));
-    if (secondaryPhoneNumber)
-      dispatch(
-        setSecondaryPhoneNumbers(
-          addToSet(secondaryPhoneNumbers, secondaryPhoneNumber)
-        )
-      );
-    if (secondaryName)
-      dispatch(setSecondaryNames(addToSet(secondaryNames, secondaryName)));
+    dispatchMappings.forEach(({ condition, action, value }) => {
+      if (condition) {
+        dispatch(action(checkAndUpdateList(value, condition)));
+      }
+    });
 
     if (props.onSubmit) {
       props.onSubmit();
@@ -160,7 +173,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     displayValue: `${locCountry.name}`,
   }));
   const countryCode = Country.getAllCountries().filter(
-    (locCountry) => country === locCountry.name
+    (locCountry) => country === locCountry.name,
   )[0]?.isoCode;
 
   const STATES = State.getStatesOfCountry(countryCode).map((locState) => ({
@@ -168,14 +181,14 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     displayValue: `${locState.name}`,
   }));
   const stateCode = State.getStatesOfCountry(countryCode).filter(
-    (locState) => locState.name === state
+    (locState) => locState.name === state,
   )[0]?.isoCode;
 
   const CITIES = City.getCitiesOfState(countryCode, stateCode).map(
     (locCity) => ({
       value: locCity.name,
       displayValue: `${locCity.name}`,
-    })
+    }),
   );
 
   return (
@@ -184,25 +197,25 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
         <div className={styles.active_patient_box}>
           <span className={styles.active_patient_box_label}>
             <ToggleButtonGroup
-              color='primary'
+              color="primary"
               value={String(active)}
               exclusive
-              aria-label='Platform'
+              aria-label="Platform"
             >
               <ToggleButton
-                value='undefined'
+                value="undefined"
                 onClick={() => dispatch(setActive(undefined))}
               >
                 All Patients
               </ToggleButton>
               <ToggleButton
-                value='true'
+                value="true"
                 onClick={() => dispatch(setActive(true))}
               >
                 Active Patients
               </ToggleButton>
               <ToggleButton
-                value='false'
+                value="false"
                 onClick={() => dispatch(setActive(false))}
               >
                 Inactive Patients
@@ -214,7 +227,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           Clear
         </div>
         <div
-          className={[styles.button_row_button, styles.button_blue].join(' ')}
+          className={[styles.button_row_button, styles.button_blue].join(" ")}
           onClick={() => {
             setFinal();
             reset();
@@ -226,15 +239,15 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
       {/* entire flexbox */}
       <div className={styles.all_questions}>
         <SelectDropdown
-          title='Country'
+          title="Country"
           dropdownProps={{
-            placeholder: 'Select Country',
+            placeholder: "Select Country",
             options: COUNTRIES,
             value: country,
             onChange: (e: SelectChangeEvent<unknown>) => {
               setCountry(e.target.value as string);
-              setState('');
-              setCity('');
+              setState("");
+              setCity("");
             },
             showError: false,
           }}
@@ -242,14 +255,14 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           answerWidth={183}
         />
         <SelectDropdown
-          title='State'
+          title="State"
           dropdownProps={{
-            placeholder: 'Select State',
+            placeholder: "Select State",
             options: STATES,
             value: state,
             onChange: (e: SelectChangeEvent<unknown>) => {
               setState(e.target.value as string);
-              setCity('');
+              setCity("");
             },
             showError: false,
           }}
@@ -257,9 +270,9 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           answerWidth={183}
         />
         <SelectDropdown
-          title='City'
+          title="City"
           dropdownProps={{
-            placeholder: 'Select City',
+            placeholder: "Select City",
             options: CITIES,
             value: city,
             onChange: (e: SelectChangeEvent<unknown>) => {
@@ -271,9 +284,9 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           answerWidth={183}
         />
         <SelectDropdown
-          title='BEI Chapter'
+          title="BEI Chapter"
           dropdownProps={{
-            placeholder: 'Select BEI Chapter',
+            placeholder: "Select BEI Chapter",
             options: CHAPTERS,
             value: beiChapter,
             onChange: (e: SelectChangeEvent<unknown>) => {
@@ -289,28 +302,28 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           <CalendarInput value={dateOfBirth} onChange={setDateOfBirth} />
         </div>
         <div className={styles.question_box}>
-          <div className={[styles.label, styles.email_label].join(' ')}>
+          <div className={[styles.label, styles.email_label].join(" ")}>
             Email Address
           </div>
           <InputField
-            type='email'
-            className={[styles.answer, styles.email_answer].join(' ')}
+            type="email"
+            className={[styles.answer, styles.email_answer].join(" ")}
             inputFieldClassName={styles.answerInput}
             value={email}
-            placeholder='example@domain.com'
+            placeholder="example@domain.com"
             onChange={(e) => setEmail(e.target.value)}
           />
         </div>
         <div className={styles.question_box}>
           <div
-            className={[styles.label, styles.additional_affil_label].join(' ')}
+            className={[styles.label, styles.additional_affil_label].join(" ")}
           >
             Additional Affiliation
           </div>
           <InputField
-            className={[styles.answer, styles.affiliation_answer].join(' ')}
+            className={[styles.answer, styles.affiliation_answer].join(" ")}
             inputFieldClassName={styles.answerInput}
-            placeholder='Enter Additional Affiliation'
+            placeholder="Enter Additional Affiliation"
             onChange={(e) => setAdditionalAffiliation(e.target.value)}
             value={additionalAffiliation}
           />
@@ -326,17 +339,17 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           </div>
           <div className={styles.question_box}>
             <div
-              className={[styles.label, styles.sec_person_name_label].join(' ')}
+              className={[styles.label, styles.sec_person_name_label].join(" ")}
             >
               First and Last Name
             </div>
             <InputField
               className={[styles.answer, styles.sec_person_name_answer].join(
-                ' '
+                " ",
               )}
               inputFieldClassName={styles.answerInput}
               required={false}
-              placeholder='Enter Name'
+              placeholder="Enter Name"
               value={secondaryName}
               onChange={(e) => setSecondaryName(e.target.value)}
             />
@@ -350,19 +363,19 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           <div className={styles.question_box}>
             <div
               className={[styles.label, styles.sec_person_phone_label].join(
-                ' '
+                " ",
               )}
             >
               Phone Number
             </div>
             <InputField
               className={[styles.answer, styles.sec_person_phone_answer].join(
-                ' '
+                " ",
               )}
               inputFieldClassName={styles.answerInput}
               required={false}
-              type='tel'
-              placeholder='Enter Phone Number'
+              type="tel"
+              placeholder="Enter Phone Number"
               value={secondaryPhoneNumber}
               onChange={(e) => setSecondaryPhoneNumber(e.target.value)}
             />

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useState } from "react";
+import React, { CSSProperties, useCallback, useState } from "react";
 import { SelectChangeEvent } from "@mui/material";
 import { Country, State, City } from "country-state-city";
 import InputField from "@src/components/InputField/InputField";
@@ -107,16 +107,16 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     (patientSearchState: RootState) => patientSearchState.patientSearch,
   );
 
-  const checkAndUpdateList = (
-    currentSet: Set<string> | undefined,
-    value: string,
-  ): Set<string> => {
-    const safeCurrentSet =
-      currentSet instanceof Set ? currentSet : new Set<string>();
-    const updatedSet = new Set(safeCurrentSet);
-    if (value) updatedSet.add(value);
-    return updatedSet;
-  };
+  const checkAndUpdateList = useCallback(
+    <T,>(currentSet: Set<T> | undefined, value: T): Set<T> => {
+      const safeCurrentSet =
+        currentSet instanceof Set ? currentSet : new Set<T>();
+      const updatedSet = new Set<T>(safeCurrentSet);
+      if (value) updatedSet.add(value);
+      return updatedSet;
+    },
+    [],
+  );
 
   const reset = () => {
     setCountry("");

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -128,7 +128,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     displayValue: `${locCountry.name}`,
   }));
   const countryCode = Country.getAllCountries().filter(
-    (locCountry) => countries === locCountry.name,
+    (locCountry) => countries === locCountry.name
   )[0]?.isoCode;
 
   const STATES = State.getStatesOfCountry(countryCode).map((locState) => ({
@@ -179,7 +179,6 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           className={[styles.button_row_button, styles.button_blue].join(' ')}
           onClick={() => {
             setFinal();
-            reset();
           }}
         >
           Apply
@@ -248,10 +247,13 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
         />
         <div className={styles.question_box}>
           <div className={styles.label}>Date of Birth</div>
-          {/* <CalendarInput
+          <CalendarInput
             value={Array.from(dateOfBirths)[0]}
-            onChange={dispatch(dateOfBirths)}
-          /> */}
+            onChange={(newDate) => {
+              const newDateOfBirths = new Set([newDate]);
+              dispatch(setDateOfBirths(newDateOfBirths));
+            }}
+          />
         </div>
         <div className={styles.question_box}>
           <div className={[styles.label, styles.email_label].join(' ')}>
@@ -284,10 +286,13 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
         </div>
         <div className={styles.question_box}>
           <div className={styles.label}>Date of Join</div>
-          {/* <CalendarInput
+          <CalendarInput
             value={Array.from(dateOfJoins)[0]}
-            onChange={dispatch(setDateOfJoins)}
-          /> */}
+            onChange={(newDate) => {
+              const newDateOfJoins = new Set([newDate]);
+              dispatch(setDateOfJoins(newDateOfJoins));
+            }}
+          />
         </div>
 
         <div className={styles.secondaryInfo}>

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -177,6 +177,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           className={[styles.button_row_button, styles.button_blue].join(' ')}
           onClick={() => {
             setFinal();
+            // reset();
           }}
         >
           Apply
@@ -191,9 +192,10 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
             options: COUNTRIES,
             value: countries,
             onChange: (e: SelectChangeEvent<unknown>) => {
+              setCountry(e.target.value as string);
+              setState('');
+              setCity('');
               dispatch(setCountries(new Set([e.target.value as string])));
-              dispatch(setStates(new Set()));
-              dispatch(setCities(new Set()));
             },
             showError: false,
           }}
@@ -207,8 +209,9 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
             options: STATES,
             value: states,
             onChange: (e: SelectChangeEvent<unknown>) => {
+              setState(e.target.value as string);
+              setCity('');
               dispatch(setStates(new Set([e.target.value as string])));
-              dispatch(setCities(new Set()));
             },
             showError: false,
           }}
@@ -222,6 +225,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
             options: CITIES,
             value: cities,
             onChange: (e: SelectChangeEvent<unknown>) => {
+              setCity(e.target.value as string);
               dispatch(setCities(new Set([e.target.value as string])));
             },
             showError: false,

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -4,18 +4,35 @@ import React, {
   SetStateAction,
   useCallback,
   CSSProperties,
-} from "react";
-import { SelectChangeEvent } from "@mui/material";
-import { Country, State, City } from "country-state-city";
-import InputField from "@src/components/InputField/InputField";
-import CHAPTERS from "@src/utils/chapters";
-import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
-import ToggleButton from "@mui/material/ToggleButton";
-import Dropdown, { DropdownProps } from "../../Dropdown/Dropdown";
-import styles from "./AdvancedSearch.module.css";
-import "react-calendar/dist/Calendar.css";
-import CalendarInput from "./CalendarInput";
+} from 'react';
+import { SelectChangeEvent } from '@mui/material';
+import { Country, State, City } from 'country-state-city';
+import InputField from '@src/components/InputField/InputField';
 
+import CHAPTERS from '@src/utils/chapters';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton';
+import Dropdown, { DropdownProps } from '../../Dropdown/Dropdown';
+import styles from './AdvancedSearch.module.css';
+import 'react-calendar/dist/Calendar.css';
+import CalendarInput from './CalendarInput';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '@src/redux/rootReducer';
+import {
+  setFullName,
+  setActive,
+  setCountries,
+  setStates,
+  setCities,
+  setDateOfBirths,
+  setEmails,
+  setAdditionalAffiliations,
+  setDateOfJoins,
+  setBeiChapters,
+  setSecondaryPhoneNumbers,
+  setSecondaryNames,
+  resetFields,
+} from '@src/redux/reducers/patientSearchReducer';
 interface SelectDropdownProps<T> {
   title: string;
   style?: CSSProperties;
@@ -43,16 +60,16 @@ function SelectDropdown<T>({
         <Dropdown
           {...dropdownProps}
           style={{
-            height: "28px",
-            width: "100%",
-            border: "none",
+            height: '28px',
+            width: '100%',
+            border: 'none',
             borderRadius: 0,
           }}
           sx={{
-            "&.MuiOutlinedInput-root": {
-              height: "30px",
-              "& fieldset": {
-                borderRadius: "0px",
+            '&.MuiOutlinedInput-root': {
+              height: '30px',
+              '& fieldset': {
+                borderRadius: '0px',
               },
             },
           }}
@@ -64,74 +81,43 @@ function SelectDropdown<T>({
 
 interface UpdateParamProp {
   style?: CSSProperties;
-  active: boolean | undefined;
-  setCountries: Dispatch<SetStateAction<Set<string>>>;
-  setStates: Dispatch<SetStateAction<Set<string>>>;
-  setCities: Dispatch<SetStateAction<Set<string>>>;
-  setActive: Dispatch<SetStateAction<boolean | undefined>>;
-  setDateOfBirths: Dispatch<SetStateAction<Set<string>>>;
-  setEmails: Dispatch<SetStateAction<Set<string>>>;
-  setDateOfJoins: Dispatch<SetStateAction<Set<string>>>;
-  setBeiChapters: Dispatch<SetStateAction<Set<string>>>;
-  setSecondaryPhoneNumbers: Dispatch<SetStateAction<Set<string>>>;
-  setAdditionalAffiliations: Dispatch<SetStateAction<Set<string>>>;
-  setSecondaryNames: Dispatch<SetStateAction<Set<string>>>;
   onSubmit?: () => void;
 }
 
 export const AdvancedSearch = (props: UpdateParamProp) => {
-  const [country, setCountry] = useState(""); // values chosen before the aply button
-  const [state, setState] = useState("");
-  const [city, setCity] = useState("");
-  const [dateOfBirth, setDateOfBirth] = useState<string>("");
-  const [email, setEmail] = useState("");
-  const [additionalAffiliation, setAdditionalAffiliation] = useState("");
-  const [dateOfJoin, setDateOfJoin] = useState<string>("");
-  const [beiChapter, setBeiChapter] = useState("");
-  const [secondaryPhoneNumber, setSecondaryPhoneNumber] = useState("");
-  const [secondaryName, setSecondaryName] = useState("");
-
-  const checkAndUpdateList = useCallback(
-    <T,>(element: T | null, setUpdater: Dispatch<SetStateAction<Set<T>>>) => {
-      setUpdater((set) => {
-        if (
-          element !== "" &&
-          element !== null &&
-          element !== undefined &&
-          !set.has(element)
-        ) {
-          const newSet = new Set<T>(set);
-          return newSet.add(element);
-        }
-        return set;
-      });
-    },
-    [],
-  );
+  const dispatch = useDispatch();
+  const {
+    fullName,
+    active,
+    countries,
+    states,
+    cities,
+    dateOfBirths,
+    emails,
+    additionalAffiliations,
+    dateOfJoins,
+    beiChapters,
+    secondaryPhoneNumbers,
+    secondaryNames,
+  } = useSelector((state: RootState) => state.patientSearch);
 
   const reset = () => {
-    setCountry("");
-    setState("");
-    setCity("");
-    setDateOfBirth("");
-    setEmail("");
-    setAdditionalAffiliation("");
-    setDateOfJoin("");
-    setSecondaryName("");
-    setSecondaryPhoneNumber("");
+    dispatch(resetFields());
   };
 
   const setFinal = () => {
-    checkAndUpdateList(country, props.setCountries);
-    checkAndUpdateList(state, props.setStates);
-    checkAndUpdateList(city, props.setCities);
-    checkAndUpdateList(dateOfBirth, props.setDateOfBirths);
-    checkAndUpdateList(email, props.setEmails);
-    checkAndUpdateList(additionalAffiliation, props.setAdditionalAffiliations);
-    checkAndUpdateList(dateOfJoin, props.setDateOfJoins);
-    checkAndUpdateList(beiChapter, props.setBeiChapters);
-    checkAndUpdateList(secondaryPhoneNumber, props.setSecondaryPhoneNumbers);
-    checkAndUpdateList(secondaryName, props.setSecondaryNames);
+    if (countries) dispatch(setCountries(countries));
+    if (states) dispatch(setStates(states));
+    if (cities) dispatch(setCities(cities));
+    if (dateOfBirths) dispatch(setDateOfBirths(dateOfBirths));
+    if (emails) dispatch(setEmails(emails));
+    if (additionalAffiliations)
+      dispatch(setAdditionalAffiliations(additionalAffiliations));
+    if (dateOfJoins) dispatch(setDateOfJoins(dateOfJoins));
+    if (beiChapters) dispatch(setBeiChapters(beiChapters));
+    if (secondaryPhoneNumbers)
+      dispatch(setSecondaryPhoneNumbers(secondaryPhoneNumbers));
+    if (secondaryNames) dispatch(setSecondaryNames(secondaryNames));
     if (props.onSubmit) {
       props.onSubmit();
     }
@@ -141,23 +127,23 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     value: locCountry.name,
     displayValue: `${locCountry.name}`,
   }));
-  const countryCode = Country.getAllCountries().filter(
-    (locCountry) => country === locCountry.name,
+  const countryCode = Country.getAllCountries().filter((locCountry) =>
+    countries.has(locCountry.name)
   )[0]?.isoCode;
 
   const STATES = State.getStatesOfCountry(countryCode).map((locState) => ({
     value: locState.name,
     displayValue: `${locState.name}`,
   }));
-  const stateCode = State.getStatesOfCountry(countryCode).filter(
-    (locState) => locState.name === state,
+  const stateCode = State.getStatesOfCountry(countryCode).filter((locState) =>
+    states.has(locState.name)
   )[0]?.isoCode;
 
   const CITIES = City.getCitiesOfState(countryCode, stateCode).map(
     (locCity) => ({
       value: locCity.name,
       displayValue: `${locCity.name}`,
-    }),
+    })
   );
 
   return (
@@ -166,24 +152,21 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
         <div className={styles.active_patient_box}>
           <span className={styles.active_patient_box_label}>
             <ToggleButtonGroup
-              color="primary"
-              value={String(props.active)}
+              color='primary'
+              value={String(active)}
               exclusive
-              aria-label="Platform"
+              aria-label='Platform'
             >
               <ToggleButton
-                value="undefined"
-                onClick={() => props.setActive(undefined)}
+                value='undefined'
+                onClick={() => setActive(undefined)}
               >
                 All Patients
               </ToggleButton>
-              <ToggleButton value="true" onClick={() => props.setActive(true)}>
+              <ToggleButton value='true' onClick={() => setActive(true)}>
                 Active Patients
               </ToggleButton>
-              <ToggleButton
-                value="false"
-                onClick={() => props.setActive(false)}
-              >
+              <ToggleButton value='false' onClick={() => setActive(false)}>
                 Inactive Patients
               </ToggleButton>
             </ToggleButtonGroup>
@@ -193,7 +176,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           Clear
         </div>
         <div
-          className={[styles.button_row_button, styles.button_blue].join(" ")}
+          className={[styles.button_row_button, styles.button_blue].join(' ')}
           onClick={() => {
             setFinal();
             reset();
@@ -205,15 +188,15 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
       {/* entire flexbox */}
       <div className={styles.all_questions}>
         <SelectDropdown
-          title="Country"
+          title='Country'
           dropdownProps={{
-            placeholder: "Select Country",
+            placeholder: 'Select Country',
             options: COUNTRIES,
-            value: country,
+            value: countries,
             onChange: (e: SelectChangeEvent<unknown>) => {
-              setCountry(e.target.value as string);
-              setState("");
-              setCity("");
+              dispatch(setCountries(new Set([e.target.value as string])));
+              dispatch(setStates(new Set()));
+              dispatch(setCities(new Set()));
             },
             showError: false,
           }}
@@ -221,14 +204,14 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           answerWidth={183}
         />
         <SelectDropdown
-          title="State"
+          title='State'
           dropdownProps={{
-            placeholder: "Select State",
+            placeholder: 'Select State',
             options: STATES,
-            value: state,
+            value: states,
             onChange: (e: SelectChangeEvent<unknown>) => {
-              setState(e.target.value as string);
-              setCity("");
+              dispatch(setStates(new Set([e.target.value as string])));
+              dispatch(setCities(new Set()));
             },
             showError: false,
           }}
@@ -236,13 +219,13 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           answerWidth={183}
         />
         <SelectDropdown
-          title="City"
+          title='City'
           dropdownProps={{
-            placeholder: "Select City",
+            placeholder: 'Select City',
             options: CITIES,
-            value: city,
+            value: cities,
             onChange: (e: SelectChangeEvent<unknown>) => {
-              setCity(e.target.value as string);
+              dispatch(setCities(new Set([e.target.value as string])));
             },
             showError: false,
           }}
@@ -250,13 +233,13 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           answerWidth={183}
         />
         <SelectDropdown
-          title="BEI Chapter"
+          title='BEI Chapter'
           dropdownProps={{
-            placeholder: "Select BEI Chapter",
+            placeholder: 'Select BEI Chapter',
             options: CHAPTERS,
-            value: beiChapter,
+            value: beiChapters,
             onChange: (e: SelectChangeEvent<unknown>) => {
-              setBeiChapter(e.target.value as string);
+              dispatch(setBeiChapters(new Set([e.target.value as string])));
             },
             showError: false,
           }}
@@ -265,38 +248,46 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
         />
         <div className={styles.question_box}>
           <div className={styles.label}>Date of Birth</div>
-          <CalendarInput value={dateOfBirth} onChange={setDateOfBirth} />
+          {/* <CalendarInput
+            value={Array.from(dateOfBirths)[0]}
+            onChange={dispatch(dateOfBirths)}
+          /> */}
         </div>
         <div className={styles.question_box}>
-          <div className={[styles.label, styles.email_label].join(" ")}>
+          <div className={[styles.label, styles.email_label].join(' ')}>
             Email Address
           </div>
           <InputField
-            type="email"
-            className={[styles.answer, styles.email_answer].join(" ")}
+            type='email'
+            className={[styles.answer, styles.email_answer].join(' ')}
             inputFieldClassName={styles.answerInput}
-            value={email}
-            placeholder="example@domain.com"
-            onChange={(e) => setEmail(e.target.value)}
+            value={Array.from(emails)[0]}
+            placeholder='example@domain.com'
+            onChange={(e) => dispatch(setEmails(new Set([e.target.value])))}
           />
         </div>
         <div className={styles.question_box}>
           <div
-            className={[styles.label, styles.additional_affil_label].join(" ")}
+            className={[styles.label, styles.additional_affil_label].join(' ')}
           >
             Additional Affiliation
           </div>
           <InputField
-            className={[styles.answer, styles.affiliation_answer].join(" ")}
+            className={[styles.answer, styles.affiliation_answer].join(' ')}
             inputFieldClassName={styles.answerInput}
-            placeholder="Enter Additional Affiliation"
-            onChange={(e) => setAdditionalAffiliation(e.target.value)}
-            value={additionalAffiliation}
+            placeholder='Enter Additional Affiliation'
+            value={Array.from(additionalAffiliations)[0]}
+            onChange={(e) =>
+              dispatch(setAdditionalAffiliations(new Set([e.target.value])))
+            }
           />
         </div>
         <div className={styles.question_box}>
           <div className={styles.label}>Date of Join</div>
-          <CalendarInput value={dateOfJoin} onChange={setDateOfJoin} />
+          {/* <CalendarInput
+            value={Array.from(dateOfJoins)[0]}
+            onChange={dispatch(setDateOfJoins)}
+          /> */}
         </div>
 
         <div className={styles.secondaryInfo}>
@@ -305,19 +296,21 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           </div>
           <div className={styles.question_box}>
             <div
-              className={[styles.label, styles.sec_person_name_label].join(" ")}
+              className={[styles.label, styles.sec_person_name_label].join(' ')}
             >
               First and Last Name
             </div>
             <InputField
               className={[styles.answer, styles.sec_person_name_answer].join(
-                " ",
+                ' '
               )}
               inputFieldClassName={styles.answerInput}
               required={false}
-              placeholder="Enter Name"
-              value={secondaryName}
-              onChange={(e) => setSecondaryName(e.target.value)}
+              placeholder='Enter Name'
+              value={Array.from(secondaryNames)[0]}
+              onChange={(e) =>
+                dispatch(setSecondaryNames(new Set([e.target.value])))
+              }
             />
           </div>
         </div>
@@ -329,21 +322,23 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           <div className={styles.question_box}>
             <div
               className={[styles.label, styles.sec_person_phone_label].join(
-                " ",
+                ' '
               )}
             >
               Phone Number
             </div>
             <InputField
               className={[styles.answer, styles.sec_person_phone_answer].join(
-                " ",
+                ' '
               )}
               inputFieldClassName={styles.answerInput}
               required={false}
-              type="tel"
-              placeholder="Enter Phone Number"
-              value={secondaryPhoneNumber}
-              onChange={(e) => setSecondaryPhoneNumber(e.target.value)}
+              type='tel'
+              placeholder='Enter Phone Number'
+              value={Array.from(secondaryPhoneNumbers)[0]}
+              onChange={(e) =>
+                dispatch(setSecondaryPhoneNumbers(new Set([e.target.value])))
+              }
             />
           </div>
         </div>

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -1,13 +1,13 @@
-import React, { CSSProperties, useState } from "react";
-import { SelectChangeEvent } from "@mui/material";
-import { Country, State, City } from "country-state-city";
-import InputField from "@src/components/InputField/InputField";
+import React, { CSSProperties, useCallback, useState } from 'react';
+import { SelectChangeEvent } from '@mui/material';
+import { Country, State, City } from 'country-state-city';
+import InputField from '@src/components/InputField/InputField';
 
-import CHAPTERS from "@src/utils/chapters";
-import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
-import ToggleButton from "@mui/material/ToggleButton";
-import { useDispatch, useSelector } from "react-redux";
-import { RootState } from "@src/redux/rootReducer";
+import CHAPTERS from '@src/utils/chapters';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '@src/redux/rootReducer';
 import {
   setActive,
   setCountries,
@@ -20,11 +20,11 @@ import {
   setBeiChapters,
   setSecondaryPhoneNumbers,
   setSecondaryNames,
-} from "@src/redux/reducers/patientSearchReducer";
-import Dropdown, { DropdownProps } from "../../Dropdown/Dropdown";
-import styles from "./AdvancedSearch.module.css";
-import "react-calendar/dist/Calendar.css";
-import CalendarInput from "./CalendarInput";
+} from '@src/redux/reducers/patientSearchReducer';
+import Dropdown, { DropdownProps } from '../../Dropdown/Dropdown';
+import styles from './AdvancedSearch.module.css';
+import 'react-calendar/dist/Calendar.css';
+import CalendarInput from './CalendarInput';
 
 interface SelectDropdownProps<T> {
   title: string;
@@ -53,16 +53,16 @@ function SelectDropdown<T>({
         <Dropdown
           {...dropdownProps}
           style={{
-            height: "28px",
-            width: "100%",
-            border: "none",
+            height: '28px',
+            width: '100%',
+            border: 'none',
             borderRadius: 0,
           }}
           sx={{
-            "&.MuiOutlinedInput-root": {
-              height: "30px",
-              "& fieldset": {
-                borderRadius: "0px",
+            '&.MuiOutlinedInput-root': {
+              height: '30px',
+              '& fieldset': {
+                borderRadius: '0px',
               },
             },
           }}
@@ -80,46 +80,76 @@ interface UpdateParamProp {
 export const AdvancedSearch = (props: UpdateParamProp) => {
   const dispatch = useDispatch();
 
-  const [country, setCountry] = useState(""); // values chosen before the aply button
-  const [state, setState] = useState("");
-  const [city, setCity] = useState("");
-  const [dateOfBirth, setDateOfBirth] = useState<string>("");
-  const [email, setEmail] = useState("");
-  const [additionalAffiliation, setAdditionalAffiliation] = useState("");
-  const [dateOfJoin, setDateOfJoin] = useState<string>("");
-  const [beiChapter, setBeiChapter] = useState("");
-  const [secondaryPhoneNumber, setSecondaryPhoneNumber] = useState("");
-  const [secondaryName, setSecondaryName] = useState("");
+  const [country, setCountry] = useState(''); // values chosen before the aply button
+  const [state, setState] = useState('');
+  const [city, setCity] = useState('');
+  const [dateOfBirth, setDateOfBirth] = useState<string>('');
+  const [email, setEmail] = useState('');
+  const [additionalAffiliation, setAdditionalAffiliation] = useState('');
+  const [dateOfJoin, setDateOfJoin] = useState<string>('');
+  const [beiChapter, setBeiChapter] = useState('');
+  const [secondaryPhoneNumber, setSecondaryPhoneNumber] = useState('');
+  const [secondaryName, setSecondaryName] = useState('');
 
-  // eslint-disable-next-line @typescript-eslint/no-shadow
-  const { active } = useSelector((state: RootState) => state.patientSearch);
+  const {
+    active,
+    countries,
+    states,
+    cities,
+    dateOfBirths,
+    emails,
+    additionalAffiliations,
+    dateOfJoins,
+    beiChapters,
+    secondaryPhoneNumbers,
+    secondaryNames,
+  } = useSelector(
+    (patientSearchState: RootState) => patientSearchState.patientSearch
+  );
 
   const reset = () => {
-    setCountry("");
-    setState("");
-    setCity("");
-    setDateOfBirth("");
-    setEmail("");
-    setAdditionalAffiliation("");
-    setDateOfJoin("");
-    setBeiChapter("");
-    setSecondaryName("");
-    setSecondaryPhoneNumber("");
+    setCountry('');
+    setState('');
+    setCity('');
+    setDateOfBirth('');
+    setEmail('');
+    setAdditionalAffiliation('');
+    setDateOfJoin('');
+    setBeiChapter('');
+    setSecondaryName('');
+    setSecondaryPhoneNumber('');
   };
 
   const setFinal = () => {
-    if (country) dispatch(setCountries(new Set([country])));
-    if (state) dispatch(setStates(new Set([state])));
-    if (city) dispatch(setCities(new Set([city])));
-    if (dateOfBirth) dispatch(setDateOfBirths(new Set([dateOfBirth])));
-    if (email) dispatch(setEmails(new Set([email])));
+    const addToSet = (currentSet: Set<string>, value: string): Set<string> => {
+      const updatedSet = new Set(currentSet);
+      if (value) updatedSet.add(value);
+      return updatedSet;
+    };
+
+    if (country) dispatch(setCountries(addToSet(countries, country)));
+    if (state) dispatch(setStates(addToSet(states, state)));
+    if (city) dispatch(setCities(addToSet(cities, city)));
+    if (dateOfBirth)
+      dispatch(setDateOfBirths(addToSet(dateOfBirths, dateOfBirth)));
+    if (email) dispatch(setEmails(addToSet(emails, email)));
     if (additionalAffiliation)
-      dispatch(setAdditionalAffiliations(new Set([additionalAffiliation])));
-    if (dateOfJoin) dispatch(setDateOfJoins(new Set([dateOfJoin])));
-    if (beiChapter) dispatch(setBeiChapters(new Set([beiChapter])));
+      dispatch(
+        setAdditionalAffiliations(
+          addToSet(additionalAffiliations, additionalAffiliation)
+        )
+      );
+    if (dateOfJoin) dispatch(setDateOfJoins(addToSet(dateOfJoins, dateOfJoin)));
+    if (beiChapter) dispatch(setBeiChapters(addToSet(beiChapters, beiChapter)));
     if (secondaryPhoneNumber)
-      dispatch(setSecondaryPhoneNumbers(new Set([secondaryPhoneNumber])));
-    if (secondaryName) dispatch(setSecondaryNames(new Set([secondaryName])));
+      dispatch(
+        setSecondaryPhoneNumbers(
+          addToSet(secondaryPhoneNumbers, secondaryPhoneNumber)
+        )
+      );
+    if (secondaryName)
+      dispatch(setSecondaryNames(addToSet(secondaryNames, secondaryName)));
+
     if (props.onSubmit) {
       props.onSubmit();
     }
@@ -130,7 +160,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     displayValue: `${locCountry.name}`,
   }));
   const countryCode = Country.getAllCountries().filter(
-    (locCountry) => country === locCountry.name,
+    (locCountry) => country === locCountry.name
   )[0]?.isoCode;
 
   const STATES = State.getStatesOfCountry(countryCode).map((locState) => ({
@@ -138,14 +168,14 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     displayValue: `${locState.name}`,
   }));
   const stateCode = State.getStatesOfCountry(countryCode).filter(
-    (locState) => locState.name === state,
+    (locState) => locState.name === state
   )[0]?.isoCode;
 
   const CITIES = City.getCitiesOfState(countryCode, stateCode).map(
     (locCity) => ({
       value: locCity.name,
       displayValue: `${locCity.name}`,
-    }),
+    })
   );
 
   return (
@@ -154,25 +184,25 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
         <div className={styles.active_patient_box}>
           <span className={styles.active_patient_box_label}>
             <ToggleButtonGroup
-              color="primary"
+              color='primary'
               value={String(active)}
               exclusive
-              aria-label="Platform"
+              aria-label='Platform'
             >
               <ToggleButton
-                value="undefined"
+                value='undefined'
                 onClick={() => dispatch(setActive(undefined))}
               >
                 All Patients
               </ToggleButton>
               <ToggleButton
-                value="true"
+                value='true'
                 onClick={() => dispatch(setActive(true))}
               >
                 Active Patients
               </ToggleButton>
               <ToggleButton
-                value="false"
+                value='false'
                 onClick={() => dispatch(setActive(false))}
               >
                 Inactive Patients
@@ -184,7 +214,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           Clear
         </div>
         <div
-          className={[styles.button_row_button, styles.button_blue].join(" ")}
+          className={[styles.button_row_button, styles.button_blue].join(' ')}
           onClick={() => {
             setFinal();
             reset();
@@ -196,15 +226,15 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
       {/* entire flexbox */}
       <div className={styles.all_questions}>
         <SelectDropdown
-          title="Country"
+          title='Country'
           dropdownProps={{
-            placeholder: "Select Country",
+            placeholder: 'Select Country',
             options: COUNTRIES,
             value: country,
             onChange: (e: SelectChangeEvent<unknown>) => {
               setCountry(e.target.value as string);
-              setState("");
-              setCity("");
+              setState('');
+              setCity('');
             },
             showError: false,
           }}
@@ -212,14 +242,14 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           answerWidth={183}
         />
         <SelectDropdown
-          title="State"
+          title='State'
           dropdownProps={{
-            placeholder: "Select State",
+            placeholder: 'Select State',
             options: STATES,
             value: state,
             onChange: (e: SelectChangeEvent<unknown>) => {
               setState(e.target.value as string);
-              setCity("");
+              setCity('');
             },
             showError: false,
           }}
@@ -227,9 +257,9 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           answerWidth={183}
         />
         <SelectDropdown
-          title="City"
+          title='City'
           dropdownProps={{
-            placeholder: "Select City",
+            placeholder: 'Select City',
             options: CITIES,
             value: city,
             onChange: (e: SelectChangeEvent<unknown>) => {
@@ -241,9 +271,9 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           answerWidth={183}
         />
         <SelectDropdown
-          title="BEI Chapter"
+          title='BEI Chapter'
           dropdownProps={{
-            placeholder: "Select BEI Chapter",
+            placeholder: 'Select BEI Chapter',
             options: CHAPTERS,
             value: beiChapter,
             onChange: (e: SelectChangeEvent<unknown>) => {
@@ -259,28 +289,28 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           <CalendarInput value={dateOfBirth} onChange={setDateOfBirth} />
         </div>
         <div className={styles.question_box}>
-          <div className={[styles.label, styles.email_label].join(" ")}>
+          <div className={[styles.label, styles.email_label].join(' ')}>
             Email Address
           </div>
           <InputField
-            type="email"
-            className={[styles.answer, styles.email_answer].join(" ")}
+            type='email'
+            className={[styles.answer, styles.email_answer].join(' ')}
             inputFieldClassName={styles.answerInput}
             value={email}
-            placeholder="example@domain.com"
+            placeholder='example@domain.com'
             onChange={(e) => setEmail(e.target.value)}
           />
         </div>
         <div className={styles.question_box}>
           <div
-            className={[styles.label, styles.additional_affil_label].join(" ")}
+            className={[styles.label, styles.additional_affil_label].join(' ')}
           >
             Additional Affiliation
           </div>
           <InputField
-            className={[styles.answer, styles.affiliation_answer].join(" ")}
+            className={[styles.answer, styles.affiliation_answer].join(' ')}
             inputFieldClassName={styles.answerInput}
-            placeholder="Enter Additional Affiliation"
+            placeholder='Enter Additional Affiliation'
             onChange={(e) => setAdditionalAffiliation(e.target.value)}
             value={additionalAffiliation}
           />
@@ -296,17 +326,17 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           </div>
           <div className={styles.question_box}>
             <div
-              className={[styles.label, styles.sec_person_name_label].join(" ")}
+              className={[styles.label, styles.sec_person_name_label].join(' ')}
             >
               First and Last Name
             </div>
             <InputField
               className={[styles.answer, styles.sec_person_name_answer].join(
-                " ",
+                ' '
               )}
               inputFieldClassName={styles.answerInput}
               required={false}
-              placeholder="Enter Name"
+              placeholder='Enter Name'
               value={secondaryName}
               onChange={(e) => setSecondaryName(e.target.value)}
             />
@@ -320,19 +350,19 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           <div className={styles.question_box}>
             <div
               className={[styles.label, styles.sec_person_phone_label].join(
-                " ",
+                ' '
               )}
             >
               Phone Number
             </div>
             <InputField
               className={[styles.answer, styles.sec_person_phone_answer].join(
-                " ",
+                ' '
               )}
               inputFieldClassName={styles.answerInput}
               required={false}
-              type="tel"
-              placeholder="Enter Phone Number"
+              type='tel'
+              placeholder='Enter Phone Number'
               value={secondaryPhoneNumber}
               onChange={(e) => setSecondaryPhoneNumber(e.target.value)}
             />

--- a/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch/AdvancedSearch.tsx
@@ -1,13 +1,13 @@
-import React, { CSSProperties, useState } from 'react';
-import { SelectChangeEvent } from '@mui/material';
-import { Country, State, City } from 'country-state-city';
-import InputField from '@src/components/InputField/InputField';
+import React, { CSSProperties, useState } from "react";
+import { SelectChangeEvent } from "@mui/material";
+import { Country, State, City } from "country-state-city";
+import InputField from "@src/components/InputField/InputField";
 
-import CHAPTERS from '@src/utils/chapters';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import ToggleButton from '@mui/material/ToggleButton';
-import { useDispatch, useSelector } from 'react-redux';
-import { RootState } from '@src/redux/rootReducer';
+import CHAPTERS from "@src/utils/chapters";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import ToggleButton from "@mui/material/ToggleButton";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@src/redux/rootReducer";
 import {
   setActive,
   setCountries,
@@ -20,11 +20,11 @@ import {
   setBeiChapters,
   setSecondaryPhoneNumbers,
   setSecondaryNames,
-} from '@src/redux/reducers/patientSearchReducer';
-import Dropdown, { DropdownProps } from '../../Dropdown/Dropdown';
-import styles from './AdvancedSearch.module.css';
-import 'react-calendar/dist/Calendar.css';
-import CalendarInput from './CalendarInput';
+} from "@src/redux/reducers/patientSearchReducer";
+import Dropdown, { DropdownProps } from "../../Dropdown/Dropdown";
+import styles from "./AdvancedSearch.module.css";
+import "react-calendar/dist/Calendar.css";
+import CalendarInput from "./CalendarInput";
 
 interface SelectDropdownProps<T> {
   title: string;
@@ -53,16 +53,16 @@ function SelectDropdown<T>({
         <Dropdown
           {...dropdownProps}
           style={{
-            height: '28px',
-            width: '100%',
-            border: 'none',
+            height: "28px",
+            width: "100%",
+            border: "none",
             borderRadius: 0,
           }}
           sx={{
-            '&.MuiOutlinedInput-root': {
-              height: '30px',
-              '& fieldset': {
-                borderRadius: '0px',
+            "&.MuiOutlinedInput-root": {
+              height: "30px",
+              "& fieldset": {
+                borderRadius: "0px",
               },
             },
           }}
@@ -78,31 +78,33 @@ interface UpdateParamProp {
 }
 
 export const AdvancedSearch = (props: UpdateParamProp) => {
-  const [country, setCountry] = useState(''); // values chosen before the aply button
-  const [state, setState] = useState('');
-  const [city, setCity] = useState('');
-  const [dateOfBirth, setDateOfBirth] = useState<string>('');
-  const [email, setEmail] = useState('');
-  const [additionalAffiliation, setAdditionalAffiliation] = useState('');
-  const [dateOfJoin, setDateOfJoin] = useState<string>('');
-  const [beiChapter, setBeiChapter] = useState('');
-  const [secondaryPhoneNumber, setSecondaryPhoneNumber] = useState('');
-  const [secondaryName, setSecondaryName] = useState('');
-
   const dispatch = useDispatch();
+
+  const [country, setCountry] = useState(""); // values chosen before the aply button
+  const [state, setState] = useState("");
+  const [city, setCity] = useState("");
+  const [dateOfBirth, setDateOfBirth] = useState<string>("");
+  const [email, setEmail] = useState("");
+  const [additionalAffiliation, setAdditionalAffiliation] = useState("");
+  const [dateOfJoin, setDateOfJoin] = useState<string>("");
+  const [beiChapter, setBeiChapter] = useState("");
+  const [secondaryPhoneNumber, setSecondaryPhoneNumber] = useState("");
+  const [secondaryName, setSecondaryName] = useState("");
+
+  // eslint-disable-next-line @typescript-eslint/no-shadow
   const { active } = useSelector((state: RootState) => state.patientSearch);
 
   const reset = () => {
-    setCountry('');
-    setState('');
-    setCity('');
-    setDateOfBirth('');
-    setEmail('');
-    setAdditionalAffiliation('');
-    setDateOfJoin('');
-    setBeiChapter('');
-    setSecondaryName('');
-    setSecondaryPhoneNumber('');
+    setCountry("");
+    setState("");
+    setCity("");
+    setDateOfBirth("");
+    setEmail("");
+    setAdditionalAffiliation("");
+    setDateOfJoin("");
+    setBeiChapter("");
+    setSecondaryName("");
+    setSecondaryPhoneNumber("");
   };
 
   const setFinal = () => {
@@ -128,7 +130,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     displayValue: `${locCountry.name}`,
   }));
   const countryCode = Country.getAllCountries().filter(
-    (locCountry) => country === locCountry.name
+    (locCountry) => country === locCountry.name,
   )[0]?.isoCode;
 
   const STATES = State.getStatesOfCountry(countryCode).map((locState) => ({
@@ -136,14 +138,14 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
     displayValue: `${locState.name}`,
   }));
   const stateCode = State.getStatesOfCountry(countryCode).filter(
-    (locState) => locState.name === state
+    (locState) => locState.name === state,
   )[0]?.isoCode;
 
   const CITIES = City.getCitiesOfState(countryCode, stateCode).map(
     (locCity) => ({
       value: locCity.name,
       displayValue: `${locCity.name}`,
-    })
+    }),
   );
 
   return (
@@ -152,25 +154,25 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
         <div className={styles.active_patient_box}>
           <span className={styles.active_patient_box_label}>
             <ToggleButtonGroup
-              color='primary'
+              color="primary"
               value={String(active)}
               exclusive
-              aria-label='Platform'
+              aria-label="Platform"
             >
               <ToggleButton
-                value='undefined'
+                value="undefined"
                 onClick={() => dispatch(setActive(undefined))}
               >
                 All Patients
               </ToggleButton>
               <ToggleButton
-                value='true'
+                value="true"
                 onClick={() => dispatch(setActive(true))}
               >
                 Active Patients
               </ToggleButton>
               <ToggleButton
-                value='false'
+                value="false"
                 onClick={() => dispatch(setActive(false))}
               >
                 Inactive Patients
@@ -182,7 +184,7 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           Clear
         </div>
         <div
-          className={[styles.button_row_button, styles.button_blue].join(' ')}
+          className={[styles.button_row_button, styles.button_blue].join(" ")}
           onClick={() => {
             setFinal();
             reset();
@@ -194,15 +196,15 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
       {/* entire flexbox */}
       <div className={styles.all_questions}>
         <SelectDropdown
-          title='Country'
+          title="Country"
           dropdownProps={{
-            placeholder: 'Select Country',
+            placeholder: "Select Country",
             options: COUNTRIES,
             value: country,
             onChange: (e: SelectChangeEvent<unknown>) => {
               setCountry(e.target.value as string);
-              setState('');
-              setCity('');
+              setState("");
+              setCity("");
             },
             showError: false,
           }}
@@ -210,14 +212,14 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           answerWidth={183}
         />
         <SelectDropdown
-          title='State'
+          title="State"
           dropdownProps={{
-            placeholder: 'Select State',
+            placeholder: "Select State",
             options: STATES,
             value: state,
             onChange: (e: SelectChangeEvent<unknown>) => {
               setState(e.target.value as string);
-              setCity('');
+              setCity("");
             },
             showError: false,
           }}
@@ -225,9 +227,9 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           answerWidth={183}
         />
         <SelectDropdown
-          title='City'
+          title="City"
           dropdownProps={{
-            placeholder: 'Select City',
+            placeholder: "Select City",
             options: CITIES,
             value: city,
             onChange: (e: SelectChangeEvent<unknown>) => {
@@ -239,9 +241,9 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           answerWidth={183}
         />
         <SelectDropdown
-          title='BEI Chapter'
+          title="BEI Chapter"
           dropdownProps={{
-            placeholder: 'Select BEI Chapter',
+            placeholder: "Select BEI Chapter",
             options: CHAPTERS,
             value: beiChapter,
             onChange: (e: SelectChangeEvent<unknown>) => {
@@ -257,28 +259,28 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           <CalendarInput value={dateOfBirth} onChange={setDateOfBirth} />
         </div>
         <div className={styles.question_box}>
-          <div className={[styles.label, styles.email_label].join(' ')}>
+          <div className={[styles.label, styles.email_label].join(" ")}>
             Email Address
           </div>
           <InputField
-            type='email'
-            className={[styles.answer, styles.email_answer].join(' ')}
+            type="email"
+            className={[styles.answer, styles.email_answer].join(" ")}
             inputFieldClassName={styles.answerInput}
             value={email}
-            placeholder='example@domain.com'
+            placeholder="example@domain.com"
             onChange={(e) => setEmail(e.target.value)}
           />
         </div>
         <div className={styles.question_box}>
           <div
-            className={[styles.label, styles.additional_affil_label].join(' ')}
+            className={[styles.label, styles.additional_affil_label].join(" ")}
           >
             Additional Affiliation
           </div>
           <InputField
-            className={[styles.answer, styles.affiliation_answer].join(' ')}
+            className={[styles.answer, styles.affiliation_answer].join(" ")}
             inputFieldClassName={styles.answerInput}
-            placeholder='Enter Additional Affiliation'
+            placeholder="Enter Additional Affiliation"
             onChange={(e) => setAdditionalAffiliation(e.target.value)}
             value={additionalAffiliation}
           />
@@ -294,17 +296,17 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           </div>
           <div className={styles.question_box}>
             <div
-              className={[styles.label, styles.sec_person_name_label].join(' ')}
+              className={[styles.label, styles.sec_person_name_label].join(" ")}
             >
               First and Last Name
             </div>
             <InputField
               className={[styles.answer, styles.sec_person_name_answer].join(
-                ' '
+                " ",
               )}
               inputFieldClassName={styles.answerInput}
               required={false}
-              placeholder='Enter Name'
+              placeholder="Enter Name"
               value={secondaryName}
               onChange={(e) => setSecondaryName(e.target.value)}
             />
@@ -318,19 +320,19 @@ export const AdvancedSearch = (props: UpdateParamProp) => {
           <div className={styles.question_box}>
             <div
               className={[styles.label, styles.sec_person_phone_label].join(
-                ' '
+                " ",
               )}
             >
               Phone Number
             </div>
             <InputField
               className={[styles.answer, styles.sec_person_phone_answer].join(
-                ' '
+                " ",
               )}
               inputFieldClassName={styles.answerInput}
               required={false}
-              type='tel'
-              placeholder='Enter Phone Number'
+              type="tel"
+              placeholder="Enter Phone Number"
               value={secondaryPhoneNumber}
               onChange={(e) => setSecondaryPhoneNumber(e.target.value)}
             />

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,16 +1,12 @@
-'use client';
+"use client";
 
-import React, { useCallback, useMemo, useState } from 'react';
-import { faSearch } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React, { useCallback, useMemo, useState } from "react";
+import { faSearch } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-import { classes, transformDate, transformPhoneNumber } from '@src/utils/utils';
-import styles from './Search.module.css';
-import Tag from './Tag/Tag';
-import { AdvancedSearch } from './AdvancedSearch/AdvancedSearch';
-import InputField from '../InputField/InputField';
-import { useDispatch, useSelector } from 'react-redux';
-import { RootState } from '@src/redux/rootReducer';
+import { classes, transformDate, transformPhoneNumber } from "@src/utils/utils";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@src/redux/rootReducer";
 import {
   setFullName,
   setActive,
@@ -25,7 +21,11 @@ import {
   setSecondaryPhoneNumbers,
   setSecondaryNames,
   resetFields,
-} from '@src/redux/reducers/patientSearchReducer';
+} from "@src/redux/reducers/patientSearchReducer";
+import styles from "./Search.module.css";
+import Tag from "./Tag/Tag";
+import { AdvancedSearch } from "./AdvancedSearch/AdvancedSearch";
+import InputField from "../InputField/InputField";
 
 interface SearchProps {
   className?: string;
@@ -96,7 +96,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
       beiChapters,
       secondaryPhoneNumbers,
       secondaryNames,
-    ]
+    ],
   );
 
   const onSubmitSearch = useCallback(() => {
@@ -108,25 +108,25 @@ export default function Search({ className, onSubmit }: SearchProps) {
   return (
     <div className={classes(styles.wrapper, className)}>
       <div className={styles.border}>
-        <div className={styles['search-no-tags']}>
-          <div className={styles['search-container']}>
+        <div className={styles["search-no-tags"]}>
+          <div className={styles["search-container"]}>
             <InputField
-              className={styles['search-bar']}
-              inputFieldClassName={styles['search-bar-input']}
+              className={styles["search-bar"]}
+              inputFieldClassName={styles["search-bar-input"]}
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
-              placeholder='Name'
+              placeholder="Name"
             />
           </div>
           <FontAwesomeIcon
-            className={styles['search-icon']}
+            className={styles["search-icon"]}
             icon={faSearch}
-            size='lg'
+            size="lg"
             onClick={onSubmitSearch}
             style={{ height: 28 }}
           />
           <p
-            className={styles['advanced-filter']}
+            className={styles["advanced-filter"]}
             onClick={() => setShowAdvancedSearch(!showAdvancedSearch)}
           >
             Advanced Filter
@@ -138,9 +138,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(countries).map((country) => (
                 <Tag
                   key={`country-${country}`}
-                  title='Country'
+                  title="Country"
                   value={country}
-                  category='countries'
+                  category="countries"
                   setAction={setCountries}
                 />
               ))}
@@ -148,9 +148,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(states).map((state) => (
                 <Tag
                   key={`state-${state}`}
-                  title='State'
+                  title="State"
                   value={state}
-                  category='states'
+                  category="states"
                   setAction={setStates}
                 />
               ))}
@@ -158,9 +158,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(cities).map((city) => (
                 <Tag
                   key={`city-${city}`}
-                  title='City'
+                  title="City"
                   value={city}
-                  category='cities'
+                  category="cities"
                   setAction={setCities}
                 />
               ))}
@@ -169,18 +169,19 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 key={`active-${active}`}
                 title='Status'
                 value={'active'}
-                category={'active'}
+                category='active'
                 transformData={(val) => (val ? 'Active' : 'Inactive')}
-                onClick={() => dispatch(setActive(undefined))}
+                setAction={}
+                onClick={}
               />
             )} */}
             {dateOfBirths.size > 0 &&
               Array.from(dateOfBirths).map((dob) => (
                 <Tag
                   key={`dob-${dob}`}
-                  title='Date of Birth'
+                  title="Date of Birth"
                   value={dob}
-                  category='dateOfBirths'
+                  category="dateOfBirths"
                   setAction={setDateOfBirths}
                   transformData={transformDate}
                 />
@@ -189,9 +190,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(emails).map((email) => (
                 <Tag
                   key={`email-${email}`}
-                  title='Email'
+                  title="Email"
                   value={email}
-                  category='emails'
+                  category="emails"
                   setAction={setEmails}
                 />
               ))}
@@ -199,9 +200,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(dateOfJoins).map((dateOfJoin) => (
                 <Tag
                   key={`join-date-${dateOfJoin}`}
-                  title='Join Date'
+                  title="Join Date"
                   value={dateOfJoin}
-                  category='dateOfJoins'
+                  category="dateOfJoins"
                   setAction={setDateOfJoins}
                   transformData={transformDate}
                 />
@@ -210,9 +211,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(beiChapters).map((chapter) => (
                 <Tag
                   key={`bei-chapter-${chapter}`}
-                  title='BEI Chapter'
+                  title="BEI Chapter"
                   value={chapter}
-                  category='beiChapters'
+                  category="beiChapters"
                   setAction={setBeiChapters}
                 />
               ))}
@@ -220,9 +221,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(secondaryPhoneNumbers).map((secondaryPhoneNumber) => (
                 <Tag
                   key={`phone-number-${secondaryPhoneNumber}`}
-                  title='Secondary Phone Number'
+                  title="Secondary Phone Number"
                   value={secondaryPhoneNumber}
-                  category='secondaryPhoneNumbers'
+                  category="secondaryPhoneNumbers"
                   setAction={setSecondaryPhoneNumbers}
                   transformData={transformPhoneNumber}
                 />
@@ -232,20 +233,20 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 (additionalAffiliation) => (
                   <Tag
                     key={`additional-affiliation-${additionalAffiliation}`}
-                    title='Additional Affiliation'
+                    title="Additional Affiliation"
                     value={additionalAffiliation}
-                    category='additionalAffiliations'
+                    category="additionalAffiliations"
                     setAction={setAdditionalAffiliations}
                   />
-                )
+                ),
               )}
             {secondaryNames.size > 0 &&
               Array.from(secondaryNames).map((secondaryName) => (
                 <Tag
                   key={`secondary-name-${secondaryName}`}
-                  title='Secondary Name'
+                  title="Secondary Name"
                   value={secondaryName}
-                  category='secondaryNames'
+                  category="secondaryNames"
                   setAction={setSecondaryNames}
                 />
               ))}
@@ -253,8 +254,8 @@ export default function Search({ className, onSubmit }: SearchProps) {
         ) : null}
         <div
           className={classes(
-            styles['advanced-search-container'],
-            showAdvancedSearch && styles['advanced-search-container-show']
+            styles["advanced-search-container"],
+            showAdvancedSearch && styles["advanced-search-container-show"],
           )}
         >
           <AdvancedSearch onSubmit={onSubmitSearch} />

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -102,25 +102,6 @@ export default function Search({ className, onSubmit }: SearchProps) {
   const onSubmitSearch = useCallback(() => {
     dispatch(setFullName(searchInput));
 
-    dispatch(setFullName('John Doe'));
-    dispatch(setActive(false));
-    dispatch(setCountries(new Set(['Country1', 'Country2'])));
-    dispatch(setStates(new Set(['State1', 'State2'])));
-    dispatch(setCities(new Set(['City1', 'City2'])));
-    dispatch(setDateOfBirths(new Set(['1990-01-01', '1992-02-02'])));
-    dispatch(setEmails(new Set(['email1@example.com', 'email2@example.com'])));
-    dispatch(
-      setAdditionalAffiliations(new Set(['Affiliation1', 'Affiliation2']))
-    );
-    dispatch(setDateOfJoins(new Set(['2020-01-01', '2022-02-02'])));
-    dispatch(setBeiChapters(new Set(['Chapter1', 'Chapter2'])));
-    dispatch(setSecondaryPhoneNumbers(new Set(['1234567890', '0987654321'])));
-    dispatch(
-      setSecondaryNames(new Set(['Secondary Name1', 'Secondary Name2']))
-    );
-
-    // dispatch(resetFields());
-
     onSubmit?.();
   }, [searchInput, dispatch, setFullName, onSubmit]);
 
@@ -188,6 +169,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 key={`active-${active}`}
                 title='Status'
                 value={'active'}
+                category={'active'}
                 transformData={(val) => (val ? 'Active' : 'Inactive')}
                 onClick={() => dispatch(setActive(undefined))}
               />
@@ -275,7 +257,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
             showAdvancedSearch && styles['advanced-search-container-show']
           )}
         >
-          {/* <AdvancedSearch onSubmit={onSubmitSearch} /> */}
+          <AdvancedSearch onSubmit={onSubmitSearch} />
         </div>
       </div>
     </div>

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -32,8 +32,6 @@ interface SearchProps {
 }
 
 export default function Search({ className, onSubmit }: SearchProps) {
-  const [searchInput, setSearchInput] = useState<string>('');
-  const [showAdvancedSearch, setShowAdvancedSearch] = useState<boolean>(false);
   const dispatch = useDispatch();
 
   const {
@@ -50,6 +48,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
     secondaryPhoneNumbers,
     secondaryNames,
   } = useSelector((state: RootState) => state.patientSearch);
+
+  const [searchInput, setSearchInput] = useState<string>(fullName);
+  const [showAdvancedSearch, setShowAdvancedSearch] = useState<boolean>(false);
 
   const tagsPresent = useMemo(
     () =>
@@ -118,7 +119,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`country-${country}`}
                   title='Country'
-                  value={'country'}
+                  value={country}
                   category='countries'
                   setAction={setCountries}
                 />
@@ -128,7 +129,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`state-${state}`}
                   title='State'
-                  value={'state'}
+                  value={state}
                   category='states'
                   setAction={setStates}
                 />
@@ -138,7 +139,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`city-${city}`}
                   title='City'
-                  value={'city'}
+                  value={city}
                   category='cities'
                   setAction={setCities}
                 />
@@ -157,7 +158,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`dob-${dob}`}
                   title='Date of Birth'
-                  value={'dob'}
+                  value={dob}
                   category='dateOfBirths'
                   setAction={setDateOfBirths}
                   transformData={transformDate}
@@ -168,7 +169,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`email-${email}`}
                   title='Email'
-                  value={'email'}
+                  value={email}
                   category='emails'
                   setAction={setEmails}
                 />
@@ -178,7 +179,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`join-date-${dateOfJoin}`}
                   title='Join Date'
-                  value={'dateOfJoin'}
+                  value={dateOfJoin}
                   category='dateOfJoins'
                   setAction={setDateOfJoins}
                   transformData={transformDate}
@@ -189,7 +190,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`bei-chapter-${chapter}`}
                   title='BEI Chapter'
-                  value={'chapter'}
+                  value={chapter}
                   category='beiChapters'
                   setAction={setBeiChapters}
                 />
@@ -211,7 +212,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                   <Tag
                     key={`additional-affiliation-${additionalAffiliation}`}
                     title='Additional Affiliation'
-                    value={'additionalAffiliation'}
+                    value={additionalAffiliation}
                     category='additionalAffiliations'
                     setAction={setAdditionalAffiliations}
                   />

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -49,24 +49,6 @@ export default function Search({ className, onSubmit }: SearchProps) {
     secondaryNames,
   } = useSelector((state: RootState) => state.patientSearch);
 
-  // Testing
-  console.log({
-    fullName,
-    active,
-    countries: Array.from(countries),
-    states: Array.from(states),
-    cities: Array.from(cities),
-    dateOfBirths: Array.from(dateOfBirths),
-    emails: Array.from(emails),
-    additionalAffiliations: Array.from(additionalAffiliations),
-    dateOfJoins: Array.from(dateOfJoins),
-    beiChapters: Array.from(beiChapters),
-    secondaryPhoneNumbers: Array.from(secondaryPhoneNumbers),
-    secondaryNames: Array.from(secondaryNames),
-  });
-
-  console.log(Array.from(emails)[0]);
-
   const [searchInput, setSearchInput] = useState<string>(fullName);
   const [showAdvancedSearch, setShowAdvancedSearch] = useState<boolean>(false);
 
@@ -167,7 +149,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
               <Tag
                 key={`active-${active}`}
                 title='Status'
-                value={'active'}
+                value={active ? 'Active' : 'Inactive'}
                 category='active'
                 transformData={(val) => (val ? 'Active' : 'Inactive')}
                 onClick={() => dispatch(setActive(undefined))}

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,86 +1,68 @@
-"use client";
+'use client';
 
-import React, { useCallback, useMemo, useState } from "react";
-import { faSearch } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React, { useCallback, useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { faSearch } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { classes, transformDate, transformPhoneNumber } from "@src/utils/utils";
-import styles from "./Search.module.css";
-import Tag from "./Tag/Tag";
-import { AdvancedSearch } from "./AdvancedSearch/AdvancedSearch";
-import InputField from "../InputField/InputField";
+import { classes, transformDate, transformPhoneNumber } from '@src/utils/utils';
+import styles from './Search.module.css';
+import Tag from './Tag/Tag';
+import { AdvancedSearch } from './AdvancedSearch/AdvancedSearch';
+import InputField from '../InputField/InputField';
+import {
+  setFullName,
+  setActive,
+  setCountries,
+  setStates,
+  setCities,
+  setDateOfBirths,
+  setEmails,
+  setAdditionalAffiliations,
+  setDateOfJoins,
+  setBeiChapters,
+  setSecondaryPhoneNumbers,
+  setSecondaryNames,
+} from '@src/redux/reducers/patientSearchReducer';
+import { RootState } from '@src/redux/rootReducer';
 
 interface SearchProps {
   className?: string;
-  setFullName: React.Dispatch<React.SetStateAction<string>>;
-  active: boolean | undefined;
-  setActive: React.Dispatch<React.SetStateAction<boolean | undefined>>;
-  countries: Set<string>;
-  setCountries: React.Dispatch<React.SetStateAction<Set<string>>>;
-  states: Set<string>;
-  setStates: React.Dispatch<React.SetStateAction<Set<string>>>;
-  cities: Set<string>;
-  setCities: React.Dispatch<React.SetStateAction<Set<string>>>;
-  dateOfBirths: Set<string>;
-  setDateOfBirths: React.Dispatch<React.SetStateAction<Set<string>>>;
-  emails: Set<string>;
-  setEmails: React.Dispatch<React.SetStateAction<Set<string>>>;
-  additionalAffiliations: Set<string>;
-  setAdditionalAffiliations: React.Dispatch<React.SetStateAction<Set<string>>>;
-  dateOfJoins: Set<string>;
-  setDateOfJoins: React.Dispatch<React.SetStateAction<Set<string>>>;
-  beiChapters: Set<string>;
-  setBeiChapters: React.Dispatch<React.SetStateAction<Set<string>>>;
-  secondaryPhoneNumbers: Set<string>;
-  setSecondaryPhoneNumbers: React.Dispatch<React.SetStateAction<Set<string>>>;
-  secondaryNames: Set<string>;
-  setSecondaryNames: React.Dispatch<React.SetStateAction<Set<string>>>;
   onSubmit?: () => void;
 }
 
-export default function Search({
-  className,
-  setFullName,
-  active,
-  setActive,
-  countries,
-  setCountries,
-  states,
-  setStates,
-  cities,
-  setCities,
-  dateOfBirths,
-  setDateOfBirths,
-  emails,
-  setEmails,
-  additionalAffiliations,
-  setAdditionalAffiliations,
-  dateOfJoins,
-  setDateOfJoins,
-  beiChapters,
-  setBeiChapters,
-  secondaryPhoneNumbers,
-  setSecondaryPhoneNumbers,
-  secondaryNames,
-  setSecondaryNames,
-  onSubmit,
-}: SearchProps) {
-  const [searchInput, setSearchInput] = useState<string>("");
+export default function Search({ className, onSubmit }: SearchProps) {
+  const [searchInput, setSearchInput] = useState<string>('');
   const [showAdvancedSearch, setShowAdvancedSearch] = useState<boolean>(false);
+
+  const dispatch = useDispatch();
+  const {
+    active,
+    countries,
+    states,
+    cities,
+    dateOfBirths,
+    emails,
+    additionalAffiliations,
+    dateOfJoins,
+    beiChapters,
+    secondaryPhones: secondaryPhoneNumbers,
+    secondaryNames,
+  } = useSelector((state: RootState) => state.patientSearch);
 
   const tagsPresent = useMemo(
     () =>
       active !== undefined ||
-      countries.size > 0 ||
-      states.size > 0 ||
-      cities.size > 0 ||
-      dateOfBirths.size > 0 ||
-      emails.size > 0 ||
-      additionalAffiliations.size > 0 ||
-      dateOfJoins.size > 0 ||
-      beiChapters.size > 0 ||
-      secondaryPhoneNumbers.size > 0 ||
-      secondaryNames.size > 0,
+      countries.length > 0 ||
+      states.length > 0 ||
+      cities.length > 0 ||
+      dateOfBirths.length > 0 ||
+      emails.length > 0 ||
+      additionalAffiliations.length > 0 ||
+      dateOfJoins.length > 0 ||
+      beiChapters.length > 0 ||
+      secondaryPhoneNumbers.length > 0 ||
+      secondaryNames.length > 0,
     [
       active,
       countries,
@@ -93,9 +75,8 @@ export default function Search({
       beiChapters,
       secondaryPhoneNumbers,
       secondaryNames,
-    ],
+    ]
   );
-
   const onSubmitSearch = useCallback(() => {
     setFullName(searchInput);
     onSubmit?.();
@@ -104,25 +85,25 @@ export default function Search({
   return (
     <div className={classes(styles.wrapper, className)}>
       <div className={styles.border}>
-        <div className={styles["search-no-tags"]}>
-          <div className={styles["search-container"]}>
+        <div className={styles['search-no-tags']}>
+          <div className={styles['search-container']}>
             <InputField
-              className={styles["search-bar"]}
-              inputFieldClassName={styles["search-bar-input"]}
+              className={styles['search-bar']}
+              inputFieldClassName={styles['search-bar-input']}
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
-              placeholder="Name"
+              placeholder='Name'
             />
           </div>
           <FontAwesomeIcon
-            className={styles["search-icon"]}
+            className={styles['search-icon']}
             icon={faSearch}
-            size="lg"
+            size='lg'
             onClick={onSubmitSearch}
             style={{ height: 28 }}
           />
           <p
-            className={styles["advanced-filter"]}
+            className={styles['advanced-filter']}
             onClick={() => setShowAdvancedSearch(!showAdvancedSearch)}
           >
             Advanced Filter
@@ -134,7 +115,7 @@ export default function Search({
               Array.from(countries).map((country) => (
                 <Tag
                   key={`country-${country}`}
-                  title="Country"
+                  title='Country'
                   value={country}
                   setList={setCountries}
                 />
@@ -143,7 +124,7 @@ export default function Search({
               Array.from(states).map((state) => (
                 <Tag
                   key={`state-${state}`}
-                  title="State"
+                  title='State'
                   value={state}
                   setList={setStates}
                 />
@@ -152,7 +133,7 @@ export default function Search({
               Array.from(cities).map((city) => (
                 <Tag
                   key={`city-${city}`}
-                  title="City"
+                  title='City'
                   value={city}
                   setList={setCities}
                 />
@@ -160,9 +141,9 @@ export default function Search({
             {active !== undefined && (
               <Tag
                 key={`active-${active}`}
-                title="Status"
+                title='Status'
                 value={active}
-                transformData={(val) => (val ? "Active" : "Inactive")}
+                transformData={(val) => (val ? 'Active' : 'Inactive')}
                 onClick={() => setActive(undefined)}
               />
             )}
@@ -170,7 +151,7 @@ export default function Search({
               Array.from(dateOfBirths).map((dob) => (
                 <Tag
                   key={`dob-${dob}`}
-                  title="Date of Birth"
+                  title='Date of Birth'
                   value={dob}
                   setList={setDateOfBirths}
                   transformData={transformDate}
@@ -180,7 +161,7 @@ export default function Search({
               Array.from(emails).map((email) => (
                 <Tag
                   key={`email-${email}`}
-                  title="Email"
+                  title='Email'
                   value={email}
                   setList={setEmails}
                 />
@@ -189,7 +170,7 @@ export default function Search({
               Array.from(dateOfJoins).map((dateOfJoin) => (
                 <Tag
                   key={`join-date-${dateOfJoin}`}
-                  title="Join Date"
+                  title='Join Date'
                   value={dateOfJoin}
                   setList={setDateOfJoins}
                   transformData={transformDate}
@@ -199,7 +180,7 @@ export default function Search({
               Array.from(beiChapters).map((chapter) => (
                 <Tag
                   key={`bei-chapter-${chapter}`}
-                  title="BEI Chapter"
+                  title='BEI Chapter'
                   value={chapter}
                   setList={setBeiChapters}
                 />
@@ -208,7 +189,7 @@ export default function Search({
               Array.from(secondaryPhoneNumbers).map((secondaryPhoneNumber) => (
                 <Tag
                   key={`phone-number-${secondaryPhoneNumber}`}
-                  title="Secondary Phone Number"
+                  title='Secondary Phone Number'
                   value={secondaryPhoneNumber}
                   setList={setSecondaryPhoneNumbers}
                   transformData={transformPhoneNumber}
@@ -219,17 +200,17 @@ export default function Search({
                 (additionalAffiliation) => (
                   <Tag
                     key={`additional-affiliation-${additionalAffiliation}`}
-                    title="Additional Affiliation"
+                    title='Additional Affiliation'
                     value={additionalAffiliation}
                     setList={setAdditionalAffiliations}
                   />
-                ),
+                )
               )}
             {secondaryNames.size > 0 &&
               Array.from(secondaryNames).map((secondaryName) => (
                 <Tag
                   key={`secondary-name-${secondaryName}`}
-                  title="Secondary Name"
+                  title='Secondary Name'
                   value={secondaryName}
                   setList={setSecondaryNames}
                 />
@@ -238,8 +219,8 @@ export default function Search({
         ) : null}
         <div
           className={classes(
-            styles["advanced-search-container"],
-            showAdvancedSearch && styles["advanced-search-container-show"],
+            styles['advanced-search-container'],
+            showAdvancedSearch && styles['advanced-search-container-show']
           )}
         >
           <AdvancedSearch

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -199,7 +199,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`phone-number-${secondaryPhoneNumber}`}
                   title='Secondary Phone Number'
-                  value={'secondaryPhoneNumber'}
+                  value={secondaryPhoneNumber}
                   category='secondaryPhoneNumbers'
                   setAction={setSecondaryPhoneNumbers}
                   transformData={transformPhoneNumber}

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,12 +1,12 @@
-"use client";
+'use client';
 
-import React, { useCallback, useMemo, useState } from "react";
-import { faSearch } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React, { useCallback, useMemo, useState } from 'react';
+import { faSearch } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { classes, transformDate, transformPhoneNumber } from "@src/utils/utils";
-import { useDispatch, useSelector } from "react-redux";
-import { RootState } from "@src/redux/rootReducer";
+import { classes, transformDate, transformPhoneNumber } from '@src/utils/utils';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '@src/redux/rootReducer';
 import {
   setFullName,
   setActive,
@@ -20,12 +20,11 @@ import {
   setBeiChapters,
   setSecondaryPhoneNumbers,
   setSecondaryNames,
-  resetFields,
-} from "@src/redux/reducers/patientSearchReducer";
-import styles from "./Search.module.css";
-import Tag from "./Tag/Tag";
-import { AdvancedSearch } from "./AdvancedSearch/AdvancedSearch";
-import InputField from "../InputField/InputField";
+} from '@src/redux/reducers/patientSearchReducer';
+import styles from './Search.module.css';
+import Tag from './Tag/Tag';
+import { AdvancedSearch } from './AdvancedSearch/AdvancedSearch';
+import InputField from '../InputField/InputField';
 
 interface SearchProps {
   className?: string;
@@ -96,7 +95,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
       beiChapters,
       secondaryPhoneNumbers,
       secondaryNames,
-    ],
+    ]
   );
 
   const onSubmitSearch = useCallback(() => {
@@ -108,25 +107,25 @@ export default function Search({ className, onSubmit }: SearchProps) {
   return (
     <div className={classes(styles.wrapper, className)}>
       <div className={styles.border}>
-        <div className={styles["search-no-tags"]}>
-          <div className={styles["search-container"]}>
+        <div className={styles['search-no-tags']}>
+          <div className={styles['search-container']}>
             <InputField
-              className={styles["search-bar"]}
-              inputFieldClassName={styles["search-bar-input"]}
+              className={styles['search-bar']}
+              inputFieldClassName={styles['search-bar-input']}
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
-              placeholder="Name"
+              placeholder='Name'
             />
           </div>
           <FontAwesomeIcon
-            className={styles["search-icon"]}
+            className={styles['search-icon']}
             icon={faSearch}
-            size="lg"
+            size='lg'
             onClick={onSubmitSearch}
             style={{ height: 28 }}
           />
           <p
-            className={styles["advanced-filter"]}
+            className={styles['advanced-filter']}
             onClick={() => setShowAdvancedSearch(!showAdvancedSearch)}
           >
             Advanced Filter
@@ -138,9 +137,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(countries).map((country) => (
                 <Tag
                   key={`country-${country}`}
-                  title="Country"
+                  title='Country'
                   value={country}
-                  category="countries"
+                  category='countries'
                   setAction={setCountries}
                 />
               ))}
@@ -148,9 +147,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(states).map((state) => (
                 <Tag
                   key={`state-${state}`}
-                  title="State"
+                  title='State'
                   value={state}
-                  category="states"
+                  category='states'
                   setAction={setStates}
                 />
               ))}
@@ -158,30 +157,29 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(cities).map((city) => (
                 <Tag
                   key={`city-${city}`}
-                  title="City"
+                  title='City'
                   value={city}
-                  category="cities"
+                  category='cities'
                   setAction={setCities}
                 />
               ))}
-            {/* {active !== undefined && (
+            {active !== undefined && (
               <Tag
                 key={`active-${active}`}
                 title='Status'
                 value={'active'}
                 category='active'
                 transformData={(val) => (val ? 'Active' : 'Inactive')}
-                setAction={}
-                onClick={}
+                onClick={() => dispatch(setActive(undefined))}
               />
-            )} */}
+            )}
             {dateOfBirths.size > 0 &&
               Array.from(dateOfBirths).map((dob) => (
                 <Tag
                   key={`dob-${dob}`}
-                  title="Date of Birth"
+                  title='Date of Birth'
                   value={dob}
-                  category="dateOfBirths"
+                  category='dateOfBirths'
                   setAction={setDateOfBirths}
                   transformData={transformDate}
                 />
@@ -190,9 +188,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(emails).map((email) => (
                 <Tag
                   key={`email-${email}`}
-                  title="Email"
+                  title='Email'
                   value={email}
-                  category="emails"
+                  category='emails'
                   setAction={setEmails}
                 />
               ))}
@@ -200,9 +198,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(dateOfJoins).map((dateOfJoin) => (
                 <Tag
                   key={`join-date-${dateOfJoin}`}
-                  title="Join Date"
+                  title='Join Date'
                   value={dateOfJoin}
-                  category="dateOfJoins"
+                  category='dateOfJoins'
                   setAction={setDateOfJoins}
                   transformData={transformDate}
                 />
@@ -211,9 +209,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(beiChapters).map((chapter) => (
                 <Tag
                   key={`bei-chapter-${chapter}`}
-                  title="BEI Chapter"
+                  title='BEI Chapter'
                   value={chapter}
-                  category="beiChapters"
+                  category='beiChapters'
                   setAction={setBeiChapters}
                 />
               ))}
@@ -221,9 +219,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(secondaryPhoneNumbers).map((secondaryPhoneNumber) => (
                 <Tag
                   key={`phone-number-${secondaryPhoneNumber}`}
-                  title="Secondary Phone Number"
+                  title='Secondary Phone Number'
                   value={secondaryPhoneNumber}
-                  category="secondaryPhoneNumbers"
+                  category='secondaryPhoneNumbers'
                   setAction={setSecondaryPhoneNumbers}
                   transformData={transformPhoneNumber}
                 />
@@ -233,20 +231,20 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 (additionalAffiliation) => (
                   <Tag
                     key={`additional-affiliation-${additionalAffiliation}`}
-                    title="Additional Affiliation"
+                    title='Additional Affiliation'
                     value={additionalAffiliation}
-                    category="additionalAffiliations"
+                    category='additionalAffiliations'
                     setAction={setAdditionalAffiliations}
                   />
-                ),
+                )
               )}
             {secondaryNames.size > 0 &&
               Array.from(secondaryNames).map((secondaryName) => (
                 <Tag
                   key={`secondary-name-${secondaryName}`}
-                  title="Secondary Name"
+                  title='Secondary Name'
                   value={secondaryName}
-                  category="secondaryNames"
+                  category='secondaryNames'
                   setAction={setSecondaryNames}
                 />
               ))}
@@ -254,8 +252,8 @@ export default function Search({ className, onSubmit }: SearchProps) {
         ) : null}
         <div
           className={classes(
-            styles["advanced-search-container"],
-            showAdvancedSearch && styles["advanced-search-container-show"],
+            styles['advanced-search-container'],
+            showAdvancedSearch && styles['advanced-search-container-show']
           )}
         >
           <AdvancedSearch onSubmit={onSubmitSearch} />

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -118,8 +118,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`country-${country}`}
                   title='Country'
-                  value={country}
-                  setList={setCountries}
+                  value={'country'}
+                  category='countries'
+                  setAction={setCountries}
                 />
               ))}
             {states.size > 0 &&
@@ -127,8 +128,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`state-${state}`}
                   title='State'
-                  value={state}
-                  setList={setStates}
+                  value={'state'}
+                  category='states'
+                  setAction={setStates}
                 />
               ))}
             {cities.size > 0 &&
@@ -136,26 +138,28 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`city-${city}`}
                   title='City'
-                  value={city}
-                  setList={setCities}
+                  value={'city'}
+                  category='cities'
+                  setAction={setCities}
                 />
               ))}
-            {active !== undefined && (
+            {/* {active !== undefined && (
               <Tag
                 key={`active-${active}`}
                 title='Status'
-                value={active}
+                value={'active'}
                 transformData={(val) => (val ? 'Active' : 'Inactive')}
-                onClick={() => setActive(undefined)}
+                onClick={() => dispatch(setActive(undefined))}
               />
-            )}
+            )} */}
             {dateOfBirths.size > 0 &&
               Array.from(dateOfBirths).map((dob) => (
                 <Tag
                   key={`dob-${dob}`}
                   title='Date of Birth'
-                  value={dob}
-                  setList={setDateOfBirths}
+                  value={'dob'}
+                  category='dateOfBirths'
+                  setAction={setDateOfBirths}
                   transformData={transformDate}
                 />
               ))}
@@ -164,8 +168,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`email-${email}`}
                   title='Email'
-                  value={email}
-                  setList={setEmails}
+                  value={'email'}
+                  category='emails'
+                  setAction={setEmails}
                 />
               ))}
             {dateOfJoins.size > 0 &&
@@ -173,8 +178,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`join-date-${dateOfJoin}`}
                   title='Join Date'
-                  value={dateOfJoin}
-                  setList={setDateOfJoins}
+                  value={'dateOfJoin'}
+                  category='dateOfJoins'
+                  setAction={setDateOfJoins}
                   transformData={transformDate}
                 />
               ))}
@@ -183,8 +189,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`bei-chapter-${chapter}`}
                   title='BEI Chapter'
-                  value={chapter}
-                  setList={setBeiChapters}
+                  value={'chapter'}
+                  category='beiChapters'
+                  setAction={setBeiChapters}
                 />
               ))}
             {secondaryPhoneNumbers.size > 0 &&
@@ -192,8 +199,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 <Tag
                   key={`phone-number-${secondaryPhoneNumber}`}
                   title='Secondary Phone Number'
-                  value={secondaryPhoneNumber}
-                  setList={setSecondaryPhoneNumbers}
+                  value={'secondaryPhoneNumber'}
+                  category='secondaryPhoneNumbers'
+                  setAction={setSecondaryPhoneNumbers}
                   transformData={transformPhoneNumber}
                 />
               ))}
@@ -203,8 +211,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
                   <Tag
                     key={`additional-affiliation-${additionalAffiliation}`}
                     title='Additional Affiliation'
-                    value={additionalAffiliation}
-                    setList={setAdditionalAffiliations}
+                    value={'additionalAffiliation'}
+                    category='additionalAffiliations'
+                    setAction={setAdditionalAffiliations}
                   />
                 )
               )}
@@ -214,7 +223,8 @@ export default function Search({ className, onSubmit }: SearchProps) {
                   key={`secondary-name-${secondaryName}`}
                   title='Secondary Name'
                   value={secondaryName}
-                  setList={setSecondaryNames}
+                  category='secondaryNames'
+                  setAction={setSecondaryNames}
                 />
               ))}
           </div>
@@ -225,8 +235,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
             showAdvancedSearch && styles['advanced-search-container-show']
           )}
         >
-          <AdvancedSearch onSubmit={onSubmitSearch}
-          />
+          {/* <AdvancedSearch onSubmit={onSubmitSearch} /> */}
         </div>
       </div>
     </div>

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -21,6 +21,7 @@ import {
   setSecondaryPhoneNumbers,
   setSecondaryNames,
 } from "@src/redux/reducers/patientSearchReducer";
+import { ActionCreatorWithPayload } from "@reduxjs/toolkit";
 import styles from "./Search.module.css";
 import Tag from "./Tag/Tag";
 import { AdvancedSearch } from "./AdvancedSearch/AdvancedSearch";
@@ -86,6 +87,17 @@ export default function Search({ className, onSubmit }: SearchProps) {
     onSubmit?.();
   }, [searchInput, dispatch, onSubmit]);
 
+  const curryOnCloseSetTag = useCallback(
+    <T,>(set: Set<T>, action: ActionCreatorWithPayload<Set<T>, string>) => {
+      return (value: T) => {
+        const updatedSet = new Set<T>(set);
+        updatedSet.delete(value);
+        dispatch(action(updatedSet));
+      };
+    },
+    [dispatch],
+  );
+
   return (
     <div className={classes(styles.wrapper, className)}>
       <div className={styles.border}>
@@ -121,8 +133,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                   key={`country-${country}`}
                   title="Country"
                   value={country}
-                  category="countries"
-                  setAction={setCountries}
+                  handleClose={curryOnCloseSetTag(countries, setCountries)}
                 />
               ))}
             {states.size > 0 &&
@@ -131,8 +142,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                   key={`state-${state}`}
                   title="State"
                   value={state}
-                  category="states"
-                  setAction={setStates}
+                  handleClose={curryOnCloseSetTag(states, setStates)}
                 />
               ))}
             {cities.size > 0 &&
@@ -141,8 +151,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                   key={`city-${city}`}
                   title="City"
                   value={city}
-                  category="cities"
-                  setAction={setCities}
+                  handleClose={curryOnCloseSetTag(cities, setCities)}
                 />
               ))}
             {active !== undefined && (
@@ -151,7 +160,6 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 title="Status"
                 value={String(active)}
                 transformData={() => (active ? "Active" : "Inactive")}
-                category="active"
                 onClick={() => {
                   dispatch(setActive(undefined));
                 }}
@@ -163,8 +171,10 @@ export default function Search({ className, onSubmit }: SearchProps) {
                   key={`dob-${dob}`}
                   title="Date of Birth"
                   value={dob}
-                  category="dateOfBirths"
-                  setAction={setDateOfBirths}
+                  handleClose={curryOnCloseSetTag(
+                    dateOfBirths,
+                    setDateOfBirths,
+                  )}
                   transformData={transformDate}
                 />
               ))}
@@ -174,8 +184,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                   key={`email-${email}`}
                   title="Email"
                   value={email}
-                  category="emails"
-                  setAction={setEmails}
+                  handleClose={curryOnCloseSetTag(emails, setEmails)}
                 />
               ))}
             {dateOfJoins.size > 0 &&
@@ -184,8 +193,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                   key={`join-date-${dateOfJoin}`}
                   title="Join Date"
                   value={dateOfJoin}
-                  category="dateOfJoins"
-                  setAction={setDateOfJoins}
+                  handleClose={curryOnCloseSetTag(dateOfJoins, setDateOfJoins)}
                   transformData={transformDate}
                 />
               ))}
@@ -195,8 +203,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
                   key={`bei-chapter-${chapter}`}
                   title="BEI Chapter"
                   value={chapter}
-                  category="beiChapters"
-                  setAction={setBeiChapters}
+                  handleClose={curryOnCloseSetTag(beiChapters, setBeiChapters)}
                 />
               ))}
             {secondaryPhoneNumbers.size > 0 &&
@@ -205,8 +212,10 @@ export default function Search({ className, onSubmit }: SearchProps) {
                   key={`phone-number-${secondaryPhoneNumber}`}
                   title="Secondary Phone Number"
                   value={secondaryPhoneNumber}
-                  category="secondaryPhoneNumbers"
-                  setAction={setSecondaryPhoneNumbers}
+                  handleClose={curryOnCloseSetTag(
+                    secondaryPhoneNumbers,
+                    setSecondaryPhoneNumbers,
+                  )}
                   transformData={transformPhoneNumber}
                 />
               ))}
@@ -217,8 +226,10 @@ export default function Search({ className, onSubmit }: SearchProps) {
                     key={`additional-affiliation-${additionalAffiliation}`}
                     title="Additional Affiliation"
                     value={additionalAffiliation}
-                    category="additionalAffiliations"
-                    setAction={setAdditionalAffiliations}
+                    handleClose={curryOnCloseSetTag(
+                      additionalAffiliations,
+                      setAdditionalAffiliations,
+                    )}
                   />
                 ),
               )}
@@ -228,8 +239,10 @@ export default function Search({ className, onSubmit }: SearchProps) {
                   key={`secondary-name-${secondaryName}`}
                   title="Secondary Name"
                   value={secondaryName}
-                  category="secondaryNames"
-                  setAction={setSecondaryNames}
+                  handleClose={curryOnCloseSetTag(
+                    secondaryNames,
+                    setSecondaryNames,
+                  )}
                 />
               ))}
           </div>

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,12 +1,12 @@
-'use client';
+"use client";
 
-import React, { useCallback, useMemo, useState } from 'react';
-import { faSearch } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React, { useCallback, useMemo, useState } from "react";
+import { faSearch } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-import { classes, transformDate, transformPhoneNumber } from '@src/utils/utils';
-import { useDispatch, useSelector } from 'react-redux';
-import { RootState } from '@src/redux/rootReducer';
+import { classes, transformDate, transformPhoneNumber } from "@src/utils/utils";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@src/redux/rootReducer";
 import {
   setFullName,
   setActive,
@@ -20,11 +20,11 @@ import {
   setBeiChapters,
   setSecondaryPhoneNumbers,
   setSecondaryNames,
-} from '@src/redux/reducers/patientSearchReducer';
-import styles from './Search.module.css';
-import Tag from './Tag/Tag';
-import { AdvancedSearch } from './AdvancedSearch/AdvancedSearch';
-import InputField from '../InputField/InputField';
+} from "@src/redux/reducers/patientSearchReducer";
+import styles from "./Search.module.css";
+import Tag from "./Tag/Tag";
+import { AdvancedSearch } from "./AdvancedSearch/AdvancedSearch";
+import InputField from "../InputField/InputField";
 
 interface SearchProps {
   className?: string;
@@ -77,37 +77,37 @@ export default function Search({ className, onSubmit }: SearchProps) {
       beiChapters,
       secondaryPhoneNumbers,
       secondaryNames,
-    ]
+    ],
   );
 
   const onSubmitSearch = useCallback(() => {
     dispatch(setFullName(searchInput));
 
     onSubmit?.();
-  }, [searchInput, dispatch, setFullName, onSubmit]);
+  }, [searchInput, dispatch, onSubmit]);
 
   return (
     <div className={classes(styles.wrapper, className)}>
       <div className={styles.border}>
-        <div className={styles['search-no-tags']}>
-          <div className={styles['search-container']}>
+        <div className={styles["search-no-tags"]}>
+          <div className={styles["search-container"]}>
             <InputField
-              className={styles['search-bar']}
-              inputFieldClassName={styles['search-bar-input']}
+              className={styles["search-bar"]}
+              inputFieldClassName={styles["search-bar-input"]}
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
-              placeholder='Name'
+              placeholder="Name"
             />
           </div>
           <FontAwesomeIcon
-            className={styles['search-icon']}
+            className={styles["search-icon"]}
             icon={faSearch}
-            size='lg'
+            size="lg"
             onClick={onSubmitSearch}
             style={{ height: 28 }}
           />
           <p
-            className={styles['advanced-filter']}
+            className={styles["advanced-filter"]}
             onClick={() => setShowAdvancedSearch(!showAdvancedSearch)}
           >
             Advanced Filter
@@ -119,9 +119,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(countries).map((country) => (
                 <Tag
                   key={`country-${country}`}
-                  title='Country'
+                  title="Country"
                   value={country}
-                  category='countries'
+                  category="countries"
                   setAction={setCountries}
                 />
               ))}
@@ -129,9 +129,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(states).map((state) => (
                 <Tag
                   key={`state-${state}`}
-                  title='State'
+                  title="State"
                   value={state}
-                  category='states'
+                  category="states"
                   setAction={setStates}
                 />
               ))}
@@ -139,29 +139,31 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(cities).map((city) => (
                 <Tag
                   key={`city-${city}`}
-                  title='City'
+                  title="City"
                   value={city}
-                  category='cities'
+                  category="cities"
                   setAction={setCities}
                 />
               ))}
             {active !== undefined && (
               <Tag
                 key={`active-${active}`}
-                title='Status'
-                value={active ? 'Active' : 'Inactive'}
-                category='active'
-                transformData={(val) => (val ? 'Active' : 'Inactive')}
-                onClick={() => dispatch(setActive(undefined))}
+                title="Status"
+                value={String(active)}
+                transformData={() => (active ? "Active" : "Inactive")}
+                category="active"
+                onClick={() => {
+                  dispatch(setActive(undefined));
+                }}
               />
             )}
             {dateOfBirths.size > 0 &&
               Array.from(dateOfBirths).map((dob) => (
                 <Tag
                   key={`dob-${dob}`}
-                  title='Date of Birth'
+                  title="Date of Birth"
                   value={dob}
-                  category='dateOfBirths'
+                  category="dateOfBirths"
                   setAction={setDateOfBirths}
                   transformData={transformDate}
                 />
@@ -170,9 +172,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(emails).map((email) => (
                 <Tag
                   key={`email-${email}`}
-                  title='Email'
+                  title="Email"
                   value={email}
-                  category='emails'
+                  category="emails"
                   setAction={setEmails}
                 />
               ))}
@@ -180,9 +182,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(dateOfJoins).map((dateOfJoin) => (
                 <Tag
                   key={`join-date-${dateOfJoin}`}
-                  title='Join Date'
+                  title="Join Date"
                   value={dateOfJoin}
-                  category='dateOfJoins'
+                  category="dateOfJoins"
                   setAction={setDateOfJoins}
                   transformData={transformDate}
                 />
@@ -191,9 +193,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(beiChapters).map((chapter) => (
                 <Tag
                   key={`bei-chapter-${chapter}`}
-                  title='BEI Chapter'
+                  title="BEI Chapter"
                   value={chapter}
-                  category='beiChapters'
+                  category="beiChapters"
                   setAction={setBeiChapters}
                 />
               ))}
@@ -201,9 +203,9 @@ export default function Search({ className, onSubmit }: SearchProps) {
               Array.from(secondaryPhoneNumbers).map((secondaryPhoneNumber) => (
                 <Tag
                   key={`phone-number-${secondaryPhoneNumber}`}
-                  title='Secondary Phone Number'
+                  title="Secondary Phone Number"
                   value={secondaryPhoneNumber}
-                  category='secondaryPhoneNumbers'
+                  category="secondaryPhoneNumbers"
                   setAction={setSecondaryPhoneNumbers}
                   transformData={transformPhoneNumber}
                 />
@@ -213,20 +215,20 @@ export default function Search({ className, onSubmit }: SearchProps) {
                 (additionalAffiliation) => (
                   <Tag
                     key={`additional-affiliation-${additionalAffiliation}`}
-                    title='Additional Affiliation'
+                    title="Additional Affiliation"
                     value={additionalAffiliation}
-                    category='additionalAffiliations'
+                    category="additionalAffiliations"
                     setAction={setAdditionalAffiliations}
                   />
-                )
+                ),
               )}
             {secondaryNames.size > 0 &&
               Array.from(secondaryNames).map((secondaryName) => (
                 <Tag
                   key={`secondary-name-${secondaryName}`}
-                  title='Secondary Name'
+                  title="Secondary Name"
                   value={secondaryName}
-                  category='secondaryNames'
+                  category="secondaryNames"
                   setAction={setSecondaryNames}
                 />
               ))}
@@ -234,8 +236,8 @@ export default function Search({ className, onSubmit }: SearchProps) {
         ) : null}
         <div
           className={classes(
-            styles['advanced-search-container'],
-            showAdvancedSearch && styles['advanced-search-container-show']
+            styles["advanced-search-container"],
+            showAdvancedSearch && styles["advanced-search-container-show"],
           )}
         >
           <AdvancedSearch onSubmit={onSubmitSearch} />

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -10,6 +9,8 @@ import styles from './Search.module.css';
 import Tag from './Tag/Tag';
 import { AdvancedSearch } from './AdvancedSearch/AdvancedSearch';
 import InputField from '../InputField/InputField';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '@src/redux/rootReducer';
 import {
   setFullName,
   setActive,
@@ -24,7 +25,6 @@ import {
   setSecondaryPhoneNumbers,
   setSecondaryNames,
 } from '@src/redux/reducers/patientSearchReducer';
-import { RootState } from '@src/redux/rootReducer';
 
 interface SearchProps {
   className?: string;
@@ -34,9 +34,10 @@ interface SearchProps {
 export default function Search({ className, onSubmit }: SearchProps) {
   const [searchInput, setSearchInput] = useState<string>('');
   const [showAdvancedSearch, setShowAdvancedSearch] = useState<boolean>(false);
-
   const dispatch = useDispatch();
+
   const {
+    fullName,
     active,
     countries,
     states,
@@ -46,23 +47,23 @@ export default function Search({ className, onSubmit }: SearchProps) {
     additionalAffiliations,
     dateOfJoins,
     beiChapters,
-    secondaryPhones: secondaryPhoneNumbers,
+    secondaryPhoneNumbers,
     secondaryNames,
   } = useSelector((state: RootState) => state.patientSearch);
 
   const tagsPresent = useMemo(
     () =>
       active !== undefined ||
-      countries.length > 0 ||
-      states.length > 0 ||
-      cities.length > 0 ||
-      dateOfBirths.length > 0 ||
-      emails.length > 0 ||
-      additionalAffiliations.length > 0 ||
-      dateOfJoins.length > 0 ||
-      beiChapters.length > 0 ||
-      secondaryPhoneNumbers.length > 0 ||
-      secondaryNames.length > 0,
+      countries.size > 0 ||
+      states.size > 0 ||
+      cities.size > 0 ||
+      dateOfBirths.size > 0 ||
+      emails.size > 0 ||
+      additionalAffiliations.size > 0 ||
+      dateOfJoins.size > 0 ||
+      beiChapters.size > 0 ||
+      secondaryPhoneNumbers.size > 0 ||
+      secondaryNames.size > 0,
     [
       active,
       countries,
@@ -77,10 +78,11 @@ export default function Search({ className, onSubmit }: SearchProps) {
       secondaryNames,
     ]
   );
+
   const onSubmitSearch = useCallback(() => {
-    setFullName(searchInput);
+    dispatch(setFullName(searchInput));
     onSubmit?.();
-  }, [searchInput, setFullName, onSubmit]);
+  }, [searchInput, dispatch, setFullName, onSubmit]);
 
   return (
     <div className={classes(styles.wrapper, className)}>
@@ -223,20 +225,7 @@ export default function Search({ className, onSubmit }: SearchProps) {
             showAdvancedSearch && styles['advanced-search-container-show']
           )}
         >
-          <AdvancedSearch
-            active={active}
-            setActive={setActive}
-            setCountries={setCountries}
-            setStates={setStates}
-            setCities={setCities}
-            setDateOfBirths={setDateOfBirths}
-            setEmails={setEmails}
-            setAdditionalAffiliations={setAdditionalAffiliations}
-            setDateOfJoins={setDateOfJoins}
-            setBeiChapters={setBeiChapters}
-            setSecondaryPhoneNumbers={setSecondaryPhoneNumbers}
-            setSecondaryNames={setSecondaryNames}
-            onSubmit={onSubmitSearch}
+          <AdvancedSearch onSubmit={onSubmitSearch}
           />
         </div>
       </div>

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -24,6 +24,7 @@ import {
   setBeiChapters,
   setSecondaryPhoneNumbers,
   setSecondaryNames,
+  resetFields,
 } from '@src/redux/reducers/patientSearchReducer';
 
 interface SearchProps {
@@ -48,6 +49,24 @@ export default function Search({ className, onSubmit }: SearchProps) {
     secondaryPhoneNumbers,
     secondaryNames,
   } = useSelector((state: RootState) => state.patientSearch);
+
+  // Testing
+  console.log({
+    fullName,
+    active,
+    countries: Array.from(countries),
+    states: Array.from(states),
+    cities: Array.from(cities),
+    dateOfBirths: Array.from(dateOfBirths),
+    emails: Array.from(emails),
+    additionalAffiliations: Array.from(additionalAffiliations),
+    dateOfJoins: Array.from(dateOfJoins),
+    beiChapters: Array.from(beiChapters),
+    secondaryPhoneNumbers: Array.from(secondaryPhoneNumbers),
+    secondaryNames: Array.from(secondaryNames),
+  });
+
+  console.log(Array.from(emails)[0]);
 
   const [searchInput, setSearchInput] = useState<string>(fullName);
   const [showAdvancedSearch, setShowAdvancedSearch] = useState<boolean>(false);
@@ -82,6 +101,26 @@ export default function Search({ className, onSubmit }: SearchProps) {
 
   const onSubmitSearch = useCallback(() => {
     dispatch(setFullName(searchInput));
+
+    dispatch(setFullName('John Doe'));
+    dispatch(setActive(false));
+    dispatch(setCountries(new Set(['Country1', 'Country2'])));
+    dispatch(setStates(new Set(['State1', 'State2'])));
+    dispatch(setCities(new Set(['City1', 'City2'])));
+    dispatch(setDateOfBirths(new Set(['1990-01-01', '1992-02-02'])));
+    dispatch(setEmails(new Set(['email1@example.com', 'email2@example.com'])));
+    dispatch(
+      setAdditionalAffiliations(new Set(['Affiliation1', 'Affiliation2']))
+    );
+    dispatch(setDateOfJoins(new Set(['2020-01-01', '2022-02-02'])));
+    dispatch(setBeiChapters(new Set(['Chapter1', 'Chapter2'])));
+    dispatch(setSecondaryPhoneNumbers(new Set(['1234567890', '0987654321'])));
+    dispatch(
+      setSecondaryNames(new Set(['Secondary Name1', 'Secondary Name2']))
+    );
+
+    // dispatch(resetFields());
+
     onSubmit?.();
   }, [searchInput, dispatch, setFullName, onSubmit]);
 

--- a/src/components/Search/Tag/Tag.tsx
+++ b/src/components/Search/Tag/Tag.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useState } from "react";
+import React from "react";
 import { faX } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ActionCreatorWithPayload } from "@reduxjs/toolkit";

--- a/src/components/Search/Tag/Tag.tsx
+++ b/src/components/Search/Tag/Tag.tsx
@@ -13,6 +13,7 @@ type TagProps<T> = {
   category: keyof IPatientSearchReducer;
   setAction: ActionCreatorWithPayload<Set<string>, string>;
   transformData?: (value: string) => string;
+  onClick?: () => void;
 };
 
 export default function Tag<T>({
@@ -20,6 +21,7 @@ export default function Tag<T>({
   value,
   category,
   setAction,
+  onClick,
   transformData,
 }: TagProps<T>) {
   const dispatch = useDispatch();
@@ -34,6 +36,9 @@ export default function Tag<T>({
     const updatedSet = new Set(categorySet);
     updatedSet.delete(value);
     dispatch(setAction(updatedSet));
+    if (onClick) {
+      onClick();
+    }
   };
 
   const tagText = transformData

--- a/src/components/Search/Tag/Tag.tsx
+++ b/src/components/Search/Tag/Tag.tsx
@@ -1,13 +1,14 @@
-import React from "react";
+import React, { useState } from "react";
 import { faX } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ActionCreatorWithPayload } from "@reduxjs/toolkit";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@src/redux/rootReducer";
 import { IPatientSearchReducer } from "@/common_utils/types";
+import { setActive } from "@src/redux/reducers/patientSearchReducer";
 import styles from "./Tag.module.css";
 
-type TagProps<T> = {
+type TagProps = {
   title: string;
   value: string;
   category: keyof IPatientSearchReducer;
@@ -16,20 +17,22 @@ type TagProps<T> = {
   onClick?: () => void;
 };
 
-export default function Tag<T>({
+export default function Tag({
   title,
   value,
   category,
   setAction,
   onClick,
   transformData,
-}: TagProps<T>) {
+}: TagProps) {
+  const [closeTag, setCloseTag] = useState(false);
   const dispatch = useDispatch();
   const categorySet = useSelector(
     (state: RootState) => state.patientSearch[category],
   );
 
   const handleCloseTag = () => {
+    setCloseTag(true);
     if (!(categorySet instanceof Set)) {
       return;
     }
@@ -44,6 +47,11 @@ export default function Tag<T>({
   const tagText = transformData
     ? `${title}: ${transformData(value)}`
     : `${title}: ${value}`;
+
+  if (closeTag) {
+    dispatch(setActive(undefined));
+    return null;
+  }
 
   return (
     <div className={styles.container}>

--- a/src/components/Search/Tag/Tag.tsx
+++ b/src/components/Search/Tag/Tag.tsx
@@ -12,7 +12,7 @@ type TagProps = {
   title: string;
   value: string;
   category: keyof IPatientSearchReducer;
-  setAction: ActionCreatorWithPayload<Set<string>, string>;
+  setAction?: ActionCreatorWithPayload<Set<string>, string>;
   transformData?: (value: string) => string;
   onClick?: () => void;
 };
@@ -38,7 +38,9 @@ export default function Tag({
     }
     const updatedSet = new Set(categorySet);
     updatedSet.delete(value);
-    dispatch(setAction(updatedSet));
+    if (setAction) {
+      dispatch(setAction(updatedSet));
+    }
     if (onClick) {
       onClick();
     }

--- a/src/components/Search/Tag/Tag.tsx
+++ b/src/components/Search/Tag/Tag.tsx
@@ -1,45 +1,29 @@
 import React, { useState } from "react";
 import { faX } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { ActionCreatorWithPayload } from "@reduxjs/toolkit";
-import { useDispatch, useSelector } from "react-redux";
-import { RootState } from "@src/redux/rootReducer";
-import { IPatientSearchReducer } from "@/common_utils/types";
-import { setActive } from "@src/redux/reducers/patientSearchReducer";
 import styles from "./Tag.module.css";
 
-type TagProps = {
+type TagProps<T> = {
   title: string;
-  value: string;
-  category: keyof IPatientSearchReducer;
-  setAction?: ActionCreatorWithPayload<Set<string>, string>;
-  transformData?: (value: string) => string;
+  value: T;
+  transformData?: (value: T) => string;
   onClick?: () => void;
+  handleClose?: (value: T) => void;
 };
 
-export default function Tag({
+export default function Tag<T>({
   title,
   value,
-  category,
-  setAction,
   onClick,
+  handleClose,
   transformData,
-}: TagProps) {
+}: TagProps<T>) {
   const [closeTag, setCloseTag] = useState(false);
-  const dispatch = useDispatch();
-  const categorySet = useSelector(
-    (state: RootState) => state.patientSearch[category],
-  );
 
   const handleCloseTag = () => {
     setCloseTag(true);
-    if (!(categorySet instanceof Set)) {
-      return;
-    }
-    const updatedSet = new Set(categorySet);
-    updatedSet.delete(value);
-    if (setAction) {
-      dispatch(setAction(updatedSet));
+    if (handleClose) {
+      handleClose(value);
     }
     if (onClick) {
       onClick();
@@ -48,10 +32,9 @@ export default function Tag({
 
   const tagText = transformData
     ? `${title}: ${transformData(value)}`
-    : `${title}: ${value}`;
+    : `${title}: ${String(value)}`;
 
   if (closeTag) {
-    dispatch(setActive(undefined));
     return null;
   }
 

--- a/src/components/Search/Tag/Tag.tsx
+++ b/src/components/Search/Tag/Tag.tsx
@@ -7,37 +7,31 @@ import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@src/redux/rootReducer';
 import { IPatientSearchReducer } from '@/common_utils/types';
 
-type TagProps = {
+type TagProps<T> = {
   title: string;
   value: string;
-  category:
-    | 'countries'
-    | 'states'
-    | 'cities'
-    | 'emails'
-    | 'dateOfBirths'
-    | 'dateOfJoins'
-    | 'beiChapters'
-    | 'secondaryPhoneNumbers'
-    | 'secondaryNames'
-    | 'additionalAffiliations';
+  category: keyof IPatientSearchReducer;
   setAction: ActionCreatorWithPayload<Set<string>, string>;
   transformData?: (value: string) => string;
 };
 
-export default function Tag({
+export default function Tag<T>({
   title,
   value,
   category,
   setAction,
   transformData,
-}: TagProps) {
+}: TagProps<T>) {
   const dispatch = useDispatch();
   const categorySet = useSelector(
     (state: RootState) => state.patientSearch[category]
   );
 
   const handleCloseTag = () => {
+    // condition to check if categorySet is a set
+    if (!(categorySet instanceof Set)) {
+      return;
+    }
     const updatedSet = new Set(categorySet);
     updatedSet.delete(value);
     dispatch(setAction(updatedSet));

--- a/src/components/Search/Tag/Tag.tsx
+++ b/src/components/Search/Tag/Tag.tsx
@@ -1,11 +1,11 @@
-import React, { Dispatch, SetStateAction, useState } from 'react';
-import { faX } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import styles from './Tag.module.css';
-import { ActionCreatorWithPayload } from '@reduxjs/toolkit';
-import { useDispatch, useSelector } from 'react-redux';
-import { RootState } from '@src/redux/rootReducer';
-import { IPatientSearchReducer } from '@/common_utils/types';
+import React, { Dispatch, SetStateAction, useState } from "react";
+import { faX } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { ActionCreatorWithPayload } from "@reduxjs/toolkit";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@src/redux/rootReducer";
+import { IPatientSearchReducer } from "@/common_utils/types";
+import styles from "./Tag.module.css";
 
 type TagProps<T> = {
   title: string;
@@ -26,7 +26,7 @@ export default function Tag<T>({
 }: TagProps<T>) {
   const dispatch = useDispatch();
   const categorySet = useSelector(
-    (state: RootState) => state.patientSearch[category]
+    (state: RootState) => state.patientSearch[category],
   );
 
   const handleCloseTag = () => {
@@ -49,8 +49,8 @@ export default function Tag<T>({
     <div className={styles.container}>
       <div className={styles.border}>
         <span className={styles.text}>{tagText}</span>
-        <div className={styles['icon-container']} onClick={handleCloseTag}>
-          <FontAwesomeIcon className={styles['x-icon']} icon={faX} size='2xs' />
+        <div className={styles["icon-container"]} onClick={handleCloseTag}>
+          <FontAwesomeIcon className={styles["x-icon"]} icon={faX} size="2xs" />
         </div>
       </div>
     </div>

--- a/src/components/Search/Tag/Tag.tsx
+++ b/src/components/Search/Tag/Tag.tsx
@@ -1,12 +1,13 @@
-import React, { Dispatch, SetStateAction, useState } from "react";
-import { faX } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import styles from "./Tag.module.css";
+import React, { Dispatch, SetStateAction, useState } from 'react';
+import { faX } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import styles from './Tag.module.css';
+import { ActionCreatorWithPayload } from '@reduxjs/toolkit';
 
 type TagProps<T> = {
   title: string;
   value: T;
-  setList?: Dispatch<SetStateAction<Set<T>>>;
+  setList?: ActionCreatorWithPayload<Set<string>>;
   transformData?: (value: T) => string;
   onClick?: () => void;
 };
@@ -50,11 +51,11 @@ export default function Tag<T>({
     <div className={styles.container}>
       <div className={styles.border}>
         <span className={styles.text}>{tagText}</span>
-        <div className={styles["icon-container"]}>
+        <div className={styles['icon-container']}>
           <FontAwesomeIcon
-            className={styles["x-icon"]}
+            className={styles['x-icon']}
             icon={faX}
-            size="2xs"
+            size='2xs'
             onClick={handleCloseTag}
           />
         </div>

--- a/src/components/Search/Tag/Tag.tsx
+++ b/src/components/Search/Tag/Tag.tsx
@@ -3,61 +3,56 @@ import { faX } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import styles from './Tag.module.css';
 import { ActionCreatorWithPayload } from '@reduxjs/toolkit';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '@src/redux/rootReducer';
+import { IPatientSearchReducer } from '@/common_utils/types';
 
-type TagProps<T> = {
+type TagProps = {
   title: string;
-  value: T;
-  setList?: ActionCreatorWithPayload<Set<string>>;
-  transformData?: (value: T) => string;
-  onClick?: () => void;
+  value: string;
+  category:
+    | 'countries'
+    | 'states'
+    | 'cities'
+    | 'emails'
+    | 'dateOfBirths'
+    | 'dateOfJoins'
+    | 'beiChapters'
+    | 'secondaryPhoneNumbers'
+    | 'secondaryNames'
+    | 'additionalAffiliations';
+  setAction: ActionCreatorWithPayload<Set<string>, string>;
+  transformData?: (value: string) => string;
 };
 
-export default function Tag<T>({
+export default function Tag({
   title,
   value,
-  setList,
+  category,
+  setAction,
   transformData,
-  onClick,
-}: TagProps<T>) {
-  const [closeTag, setCloseTag] = useState(false);
+}: TagProps) {
+  const dispatch = useDispatch();
+  const categorySet = useSelector(
+    (state: RootState) => state.patientSearch[category]
+  );
 
   const handleCloseTag = () => {
-    setCloseTag(true);
-    if (setList) {
-      setList((list) => {
-        const newList = new Set<T>(list);
-        newList.delete(value);
-        return newList;
-      });
-    }
-    if (onClick) {
-      onClick();
-    }
+    const updatedSet = new Set(categorySet);
+    updatedSet.delete(value);
+    dispatch(setAction(updatedSet));
   };
 
-  let tagText = `${title}: `;
-
-  if (transformData) {
-    tagText += transformData(value);
-  } else {
-    tagText += value;
-  }
-
-  if (closeTag) {
-    return null;
-  }
+  const tagText = transformData
+    ? `${title}: ${transformData(value)}`
+    : `${title}: ${value}`;
 
   return (
     <div className={styles.container}>
       <div className={styles.border}>
         <span className={styles.text}>{tagText}</span>
-        <div className={styles['icon-container']}>
-          <FontAwesomeIcon
-            className={styles['x-icon']}
-            icon={faX}
-            size='2xs'
-            onClick={handleCloseTag}
-          />
+        <div className={styles['icon-container']} onClick={handleCloseTag}>
+          <FontAwesomeIcon className={styles['x-icon']} icon={faX} size='2xs' />
         </div>
       </div>
     </div>

--- a/src/components/Search/Tag/Tag.tsx
+++ b/src/components/Search/Tag/Tag.tsx
@@ -28,7 +28,6 @@ export default function Tag<T>({
   );
 
   const handleCloseTag = () => {
-    // condition to check if categorySet is a set
     if (!(categorySet instanceof Set)) {
       return;
     }

--- a/src/redux/reducers/patientSearchReducer/index.ts
+++ b/src/redux/reducers/patientSearchReducer/index.ts
@@ -1,0 +1,77 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { PatientSearchParams } from '@/common_utils/types';
+
+const initialState: PatientSearchParams = {
+  name: '',
+  active: undefined,
+  countries: [],
+  states: [],
+  cities: [],
+  dateOfBirths: [],
+  emails: [],
+  additionalAffiliations: [],
+  dateOfJoins: [],
+  beiChapters: [],
+  secondaryPhones: [],
+  secondaryNames: [],
+};
+
+const patientSearchReducer = createSlice({
+  name: 'patientSearch',
+  initialState,
+  reducers: {
+    setFullName(state, action: PayloadAction<string | undefined>) {
+      state.name = action.payload;
+    },
+    setActive(state, action: PayloadAction<boolean | undefined>) {
+      state.active = action.payload;
+    },
+    setCountries(state, action: PayloadAction<string[]>) {
+      state.countries = action.payload;
+    },
+    setStates(state, action: PayloadAction<string[]>) {
+      state.states = action.payload;
+    },
+    setCities(state, action: PayloadAction<string[]>) {
+      state.cities = action.payload;
+    },
+    setDateOfBirths(state, action: PayloadAction<string[]>) {
+      state.dateOfBirths = action.payload;
+    },
+    setEmails(state, action: PayloadAction<string[]>) {
+      state.emails = action.payload;
+    },
+    setAdditionalAffiliations(state, action: PayloadAction<string[]>) {
+      state.additionalAffiliations = action.payload;
+    },
+    setDateOfJoins(state, action: PayloadAction<string[]>) {
+      state.dateOfJoins = action.payload;
+    },
+    setBeiChapters(state, action: PayloadAction<string[]>) {
+      state.beiChapters = action.payload;
+    },
+    setSecondaryPhoneNumbers(state, action: PayloadAction<string[]>) {
+      state.secondaryPhones = action.payload;
+    },
+    setSecondaryNames(state, action: PayloadAction<string[]>) {
+      state.secondaryNames = action.payload;
+    },
+  },
+});
+
+export const {
+  setFullName,
+  setActive,
+  setCountries,
+  setStates,
+  setCities,
+  setDateOfBirths,
+  setEmails,
+  setAdditionalAffiliations,
+  setDateOfJoins,
+  setBeiChapters,
+  setSecondaryPhoneNumbers,
+  setSecondaryNames,
+} = patientSearchReducer.actions;
+
+export default patientSearchReducer.reducer;

--- a/src/redux/reducers/patientSearchReducer/index.ts
+++ b/src/redux/reducers/patientSearchReducer/index.ts
@@ -1,59 +1,59 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { PatientSearchParams } from '@/common_utils/types';
 
-const initialState: PatientSearchParams = {
-  name: '',
+const initialState = {
+  fullName: '',
   active: undefined,
-  countries: [],
-  states: [],
-  cities: [],
-  dateOfBirths: [],
-  emails: [],
-  additionalAffiliations: [],
-  dateOfJoins: [],
-  beiChapters: [],
-  secondaryPhones: [],
-  secondaryNames: [],
+  countries: new Set<string>(),
+  states: new Set<string>(),
+  cities: new Set<string>(),
+  dateOfBirths: new Set<string>(),
+  emails: new Set<string>(),
+  additionalAffiliations: new Set<string>(),
+  dateOfJoins: new Set<string>(),
+  beiChapters: new Set<string>(),
+  secondaryPhoneNumbers: new Set<string>(),
+  secondaryNames: new Set<string>(),
 };
 
 const patientSearchReducer = createSlice({
   name: 'patientSearch',
   initialState,
   reducers: {
-    setFullName(state, action: PayloadAction<string | undefined>) {
-      state.name = action.payload;
+    setFullName(state, action: PayloadAction<string>) {
+      state.fullName = action.payload;
     },
     setActive(state, action: PayloadAction<boolean | undefined>) {
       state.active = action.payload;
     },
-    setCountries(state, action: PayloadAction<string[]>) {
+    setCountries(state, action: PayloadAction<Set<string>>) {
       state.countries = action.payload;
     },
-    setStates(state, action: PayloadAction<string[]>) {
+    setStates(state, action: PayloadAction<Set<string>>) {
       state.states = action.payload;
     },
-    setCities(state, action: PayloadAction<string[]>) {
+    setCities(state, action: PayloadAction<Set<string>>) {
       state.cities = action.payload;
     },
-    setDateOfBirths(state, action: PayloadAction<string[]>) {
+    setDateOfBirths(state, action: PayloadAction<Set<string>>) {
       state.dateOfBirths = action.payload;
     },
-    setEmails(state, action: PayloadAction<string[]>) {
+    setEmails(state, action: PayloadAction<Set<string>>) {
       state.emails = action.payload;
     },
-    setAdditionalAffiliations(state, action: PayloadAction<string[]>) {
+    setAdditionalAffiliations(state, action: PayloadAction<Set<string>>) {
       state.additionalAffiliations = action.payload;
     },
-    setDateOfJoins(state, action: PayloadAction<string[]>) {
+    setDateOfJoins(state, action: PayloadAction<Set<string>>) {
       state.dateOfJoins = action.payload;
     },
-    setBeiChapters(state, action: PayloadAction<string[]>) {
+    setBeiChapters(state, action: PayloadAction<Set<string>>) {
       state.beiChapters = action.payload;
     },
-    setSecondaryPhoneNumbers(state, action: PayloadAction<string[]>) {
-      state.secondaryPhones = action.payload;
+    setSecondaryPhoneNumbers(state, action: PayloadAction<Set<string>>) {
+      state.secondaryPhoneNumbers = action.payload;
     },
-    setSecondaryNames(state, action: PayloadAction<string[]>) {
+    setSecondaryNames(state, action: PayloadAction<Set<string>>) {
       state.secondaryNames = action.payload;
     },
   },

--- a/src/redux/reducers/patientSearchReducer/index.ts
+++ b/src/redux/reducers/patientSearchReducer/index.ts
@@ -1,8 +1,10 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { IPatientSearchReducer } from '@/common_utils/types';
+/* eslint-disable no-param-reassign */
+
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { IPatientSearchReducer } from "@/common_utils/types";
 
 const initialState: IPatientSearchReducer = {
-  fullName: '',
+  fullName: "",
   active: undefined,
   countries: new Set<string>(),
   states: new Set<string>(),
@@ -17,7 +19,7 @@ const initialState: IPatientSearchReducer = {
 };
 
 const patientSearchReducer = createSlice({
-  name: 'patientSearch',
+  name: "patientSearch",
   initialState,
   reducers: {
     setFullName(state, action: PayloadAction<string>) {

--- a/src/redux/reducers/patientSearchReducer/index.ts
+++ b/src/redux/reducers/patientSearchReducer/index.ts
@@ -56,6 +56,20 @@ const patientSearchReducer = createSlice({
     setSecondaryNames(state, action: PayloadAction<Set<string>>) {
       state.secondaryNames = action.payload;
     },
+    resetFields(state) {
+      state.fullName = initialState.fullName;
+      state.active = initialState.active;
+      state.countries = initialState.countries;
+      state.states = initialState.states;
+      state.cities = initialState.cities;
+      state.dateOfBirths = initialState.dateOfBirths;
+      state.emails = initialState.emails;
+      state.additionalAffiliations = initialState.additionalAffiliations;
+      state.dateOfJoins = initialState.dateOfJoins;
+      state.beiChapters = initialState.beiChapters;
+      state.secondaryPhoneNumbers = initialState.secondaryPhoneNumbers;
+      state.secondaryNames = initialState.secondaryNames;
+    },
   },
 });
 
@@ -72,6 +86,7 @@ export const {
   setBeiChapters,
   setSecondaryPhoneNumbers,
   setSecondaryNames,
+  resetFields,
 } = patientSearchReducer.actions;
 
 export default patientSearchReducer.reducer;

--- a/src/redux/reducers/patientSearchReducer/index.ts
+++ b/src/redux/reducers/patientSearchReducer/index.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { PatientSearchParams } from '@/common_utils/types';
+import { IPatientSearchReducer } from '@/common_utils/types';
 
-const initialState = {
+const initialState: IPatientSearchReducer = {
   fullName: '',
   active: undefined,
   countries: new Set<string>(),

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -1,12 +1,12 @@
-'use client';
+"use client";
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { combineReducers } from '@reduxjs/toolkit';
-import { persistReducer } from 'redux-persist';
-import createWebStorage from 'redux-persist/lib/storage/createWebStorage';
+import { combineReducers } from "@reduxjs/toolkit";
+import { persistReducer } from "redux-persist";
+import createWebStorage from "redux-persist/lib/storage/createWebStorage";
 
-import authReducer from './reducers/authReducer';
-import patientSearchReducer from './reducers/patientSearchReducer';
+import authReducer from "./reducers/authReducer";
+import patientSearchReducer from "./reducers/patientSearchReducer";
 
 const createNoopStorage = () => {
   return {
@@ -23,12 +23,12 @@ const createNoopStorage = () => {
 };
 
 const storage =
-  typeof window !== 'undefined'
-    ? createWebStorage('local')
+  typeof window !== "undefined"
+    ? createWebStorage("local")
     : createNoopStorage();
 
 const persistConfig = {
-  key: 'root',
+  key: "root",
   storage,
 };
 
@@ -37,7 +37,7 @@ const rootReducer = persistReducer(
   combineReducers({
     auth: authReducer,
     patientSearch: patientSearchReducer,
-  })
+  }),
 );
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -1,11 +1,12 @@
-"use client";
+'use client';
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { combineReducers } from "@reduxjs/toolkit";
-import { persistReducer } from "redux-persist";
-import createWebStorage from "redux-persist/lib/storage/createWebStorage";
+import { combineReducers } from '@reduxjs/toolkit';
+import { persistReducer } from 'redux-persist';
+import createWebStorage from 'redux-persist/lib/storage/createWebStorage';
 
-import authReducer from "./reducers/authReducer";
+import authReducer from './reducers/authReducer';
+import patientSearchReducer from './reducers/patientSearchReducer';
 
 const createNoopStorage = () => {
   return {
@@ -22,12 +23,12 @@ const createNoopStorage = () => {
 };
 
 const storage =
-  typeof window !== "undefined"
-    ? createWebStorage("local")
+  typeof window !== 'undefined'
+    ? createWebStorage('local')
     : createNoopStorage();
 
 const persistConfig = {
-  key: "root",
+  key: 'root',
   storage,
 };
 
@@ -35,7 +36,8 @@ const rootReducer = persistReducer(
   persistConfig,
   combineReducers({
     auth: authReducer,
-  }),
+    patientSearch: patientSearchReducer,
+  })
 );
 
 export type RootState = ReturnType<typeof rootReducer>;


### PR DESCRIPTION
## [Frontend-ish] Store Patient Filters in Redux Reducer

Issue Number(s): #90 

What does this PR change and why?
Currently, we store all the patient search (page - `/patient/search`; file - `/src/app/(management-portal)/patient/search/page.tsx`) filters as states in the page. We want a way for these filters to persist across page reloads and across different pages (eg: new feature - group analytics).


### Checklist
- [x] Create `patientSearchReducer` with appropriate actions
- [x] Refactor the code to use this reducer, using `useDispatch` and `useState`

### Critical Changes

- Database change/migration to run
- Environment config change
- Breaking API change

### Related PRs

- #number_of_pr

### Testing

Enumerate steps to test the functionality of your ticket. This should include edge cases and testing of error handling, if applicable.
