### PR TITLE
flip arrows on grid

### DIFF
--- a/src/components/DataGrid/DataGrid.tsx
+++ b/src/components/DataGrid/DataGrid.tsx
@@ -39,7 +39,7 @@ function SortButton({
         !active && styles.SortButtonInactive,
       )}
       onClick={handleClick}
-      icon={active && !sortField.ascending ? faCaretDown : faCaretUp}
+      icon={active && !sortField.ascending ? faCaretUp : faCaretDown}
     />
   );
 }


### PR DESCRIPTION
## PR Title

Issue Number(s): #145 .

flips arrow on grid. originally was supposed to investigate why arrows dont change until second click but i think thats the intended behavior? on first click, the column gets sorted in the direction the arrow is pointing (previously unsorted) so the direction doesn't change. second click flips it.

flipped arrow directions to be more intuitive.